### PR TITLE
Add SBOM generator action

### DIFF
--- a/sbom-generator/README.md
+++ b/sbom-generator/README.md
@@ -1,0 +1,55 @@
+# sbom-generator
+
+Generates the [CycloneDX] SBOM of a given project, and fetches dependencies licenses using [`cdxgen`].
+
+
+## Usage
+
+### GitHub Action
+
+```yaml
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+    paths:
+      # Python Ecosystem
+      - "**/pyproject.toml"
+      - "**/setup.py"
+      - "**/requirements*.txt"
+      - "**/Pipfile.lock"
+      - "**/poetry.lock"
+      # JS/TS Ecosystem
+      - "**/package.json"
+      - "**/pnpm-lock.yaml"
+      - "**/package-lock.json"
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Analyze Licenses
+        uses: saleor/saleor-internal-actions/sbom-generator@v0
+        with:
+          # Where to store the resulting SBOM file (default is ./sbom.json).
+          sbom_path: ./sbom.json
+          # The project to scan (default is ./).
+          project_path: ./
+          # The ecosystems to scan, scans all by default.
+          #
+          # See https://cyclonedx.github.io/cdxgen/#/PROJECT_TYPES for the supported
+          # ecosystems ("Project Types" column).
+          ecosystems: |
+            python
+            javascript
+```
+
+[`cdxgen`]: https://github.com/CycloneDX/cdxgen/
+[CycloneDX]: https://cyclonedx.org/

--- a/sbom-generator/action.yaml
+++ b/sbom-generator/action.yaml
@@ -1,0 +1,48 @@
+name: grant-license-checker
+description: >-
+  Generates a CycloneDX SBOM with license fetching enabled.
+inputs:
+  cdxgen_version:
+    default: "10.9.5"
+    description: >-
+      The cdxgen version to use to generate the CycloneDX SBOM.
+      List of available versions: https://github.com/CycloneDX/cdxgen/releases.
+  sbom_path:
+    default: "./sbom.json"
+    description: >-
+      Path where to store the generated SBOM.
+  project_path:
+    default: "."
+    description: >-
+      The path of the project to analyze. Defaults to current working directory.
+  ecosystems:
+    description: >-
+      The project types to support, e.g., `python` or `javascript` (delimited by spaces or newlines).
+      
+      List of supported values: https://cyclonedx.github.io/cdxgen/#/PROJECT_TYPES
+      ("Project Types" column).
+      
+      Default: scan all.
+runs:
+  using: composite
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+
+    - name: Install cdxgen
+      shell: bash
+      env:
+        CONF_CDXGEN_VERSION: "${{ inputs.cdxgen_version }}"
+      run: |
+        npm install -g "@cyclonedx/cdxgen@$CONF_CDXGEN_VERSION"
+
+    - name: Generate SBOM
+      shell: bash
+      env:
+        CONF_PROJECT_DIR: "${{ inputs.project_path }}"
+        CONF_ECOSYSTEMS: "${{ inputs.ecosystems }}"
+        CONF_RESULT_PATH: "${{ inputs.sbom_path }}"
+      run: |
+        "${GITHUB_ACTION_PATH}/scripts/generate-sbom.sh"

--- a/sbom-generator/scripts/generate-sbom.sh
+++ b/sbom-generator/scripts/generate-sbom.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+function log() {
+    msg="$1"
+    shift
+    # shellcheck disable=SC2059 # "$1" for printf is assumed safe.
+    printf "$msg\n" "$@" >&2
+}
+
+# Add extra logging if the runner was run with debug logging.
+test -z "${RUNNER_DEBUG+x}" || set -x
+
+# User provided preferences:
+# - CONF_PROJECT_DIR: the path of the project to scan (relative or absolute).
+# - CONF_ECOSYSTEMS: list of ecosystems to scan (e.g., python), whitespace separated.
+# - CONF_RESULT_PATH: the path where to store the SBOM.
+CONF_PROJECT_DIR="${CONF_PROJECT_DIR:-$PWD}"
+CONF_ECOSYSTEMS="${CONF_ECOSYSTEMS:-}"
+CONF_RESULT_PATH=${CONF_RESULT_PATH:-./bom.json}
+
+cmd_args=(
+    "--recurse"
+    "--output=$CONF_RESULT_PATH"
+    "--profile=license-compliance"
+    # Path to the source code to analyze (inside the mounted container)
+    "$CONF_PROJECT_DIR"
+)
+
+# Add project types into the 'cdxgen' command line argument list.
+read -d '' -r -a ecosystems < <(echo "$CONF_ECOSYSTEMS") || true
+for ecosystem in "${ecosystems[@]}"; do
+    cmd_args+=( "--type=$ecosystem" )
+done
+
+# Generate the BOM.
+log "Generating SBOM..."
+FETCH_LICENSE=true cdxgen "${cmd_args[@]}"

--- a/sbom-generator/scripts/generate-sbom.sh
+++ b/sbom-generator/scripts/generate-sbom.sh
@@ -24,7 +24,7 @@ cmd_args=(
     "--recurse"
     "--output=$CONF_RESULT_PATH"
     "--profile=license-compliance"
-    # Path to the source code to analyze (inside the mounted container)
+    # Path to the source code to analyze
     "$CONF_PROJECT_DIR"
 )
 


### PR DESCRIPTION
This adds a GitHub Action that generates a Software Bill of Material (SBOM) using the [CycloneDX] format (via the [`cdxgen`] command).

This allows us to generate a list of dependencies (main & transient), and fetch the licenses (from PyPI and NPM for example).

[`cdxgen`]: https://github.com/CycloneDX/cdxgen/
[CycloneDX]: https://cyclonedx.org/