### PR TITLE
Release v1.0.0

### DIFF
--- a/.github/workflows/run-license-check.yaml
+++ b/.github/workflows/run-license-check.yaml
@@ -71,7 +71,7 @@ jobs:
       # reusable workflows.
       - if: ${{ !endsWith(github.repository, '/saleor-internal-actions') }}
         name: Generate SBOM
-        uses: saleor/saleor-internal-actions/sbom-generator@main
+        uses: saleor/saleor-internal-actions/sbom-generator@v1
         with:
           sbom_path: "./bom.json"
           ecosystems: ${{ inputs.ecosystems }}
@@ -155,7 +155,7 @@ jobs:
       - id: license-analyzer-workflow-call
         if: ${{ !endsWith(github.repository, '/saleor-internal-actions') }}
         name: Analyze Licenses
-        uses: saleor/saleor-internal-actions/grant-license-checker@main
+        uses: saleor/saleor-internal-actions/grant-license-checker@v1
         with:
           rules: ${{ inputs.rules }}
           sbom_path: ./bom.json

--- a/grant-license-checker/README.md
+++ b/grant-license-checker/README.md
@@ -89,7 +89,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Analyze Licenses
-        uses: saleor/saleor-internal-actions/grant-license-checker@v0
+        uses: saleor/saleor-internal-actions/grant-license-checker@v1
         with:
           # Needs to be a SBOM that contains license information (SPDX, CycloneDX,
           # and Syft formats are supported).
@@ -137,7 +137,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: saleor/saleor-internal-actions/.github/workflows/run-license-check.yaml@v0
+    uses: saleor/saleor-internal-actions/.github/workflows/run-license-check.yaml@v1
 ```
 
 ### CLI

--- a/sbom-generator/README.md
+++ b/sbom-generator/README.md
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Analyze Licenses
-        uses: saleor/saleor-internal-actions/sbom-generator@v0
+        uses: saleor/saleor-internal-actions/sbom-generator@v1
         with:
           # Where to store the resulting SBOM file (default is ./sbom.json).
           sbom_path: ./sbom.json


### PR DESCRIPTION
This changes the documentation and workflows to use v1 instead of `main` (or `v0`) in order to release the first version (v1.0.0, and aliased to v1)