### PR TITLE
fix: missing input variable in license checker

### DIFF
--- a/.github/workflows/run-generate-sbom-and-check-licenses.yaml
+++ b/.github/workflows/run-generate-sbom-and-check-licenses.yaml
@@ -171,6 +171,7 @@ jobs:
         with:
           rules: ${{ inputs.rules }}
           sbom_path: ./bom.json
+          output_formats: ${{ inputs.output_formats }}
 
       - name: Upload Analysis Results
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0


### PR DESCRIPTION
The license checker was missing an input variable when running the action inside an external repository, this was causing the workflow to error-out.

It was mismatching with: https://github.com/saleor/saleor-internal-actions/blob/6815d5d5991ebcb5ef262cc579a591a7a0898d03/.github/workflows/run-generate-sbom-and-check-licenses.yaml#L158-L165