### PR TITLE
fix: debug logging was enabled by default

### DIFF
--- a/.github/workflows/run-generate-sbom-and-check-licenses.yaml
+++ b/.github/workflows/run-generate-sbom-and-check-licenses.yaml
@@ -141,7 +141,7 @@ jobs:
       # Ticket: https://github.com/anchore/syft/issues/1202
       - name: Prepend Dependency Group
         run: |
-          test -n "${RUNNER_DEBUG+x}" || set -x
+          test -z "${RUNNER_DEBUG+x}" || set -x
           set -eu
           
           # When .group is not blank, preprend .group into .name (using a slash (/))

--- a/.github/workflows/run-license-check.yaml
+++ b/.github/workflows/run-license-check.yaml
@@ -181,7 +181,7 @@ jobs:
       - name: Validate HTML Report
         shell: bash
         run: |
-          test -n "${RUNNER_DEBUG+x}" || set -x
+          test -z "${RUNNER_DEBUG+x}" || set -x
 
           # Append into the file the comment suffix,
           # but ensure it exists in order to prevent sending empty comments
@@ -214,7 +214,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           OLD_COMMENT_ID: ${{ steps.find-previous-comment.outputs.comment-id }}
         run: |
-          test -n "${RUNNER_DEBUG+x}" || set -x
+          test -z "${RUNNER_DEBUG+x}" || set -x
 
           endpoint="/repos/${GITHUB_REPOSITORY}/issues"
           


### PR DESCRIPTION
The license checking and SBOM generator actions had a logic error which caused the debug logging to be enabled by default instead of being "opt-in" (whenever the invoker re-runs the workflow with "Enable debug logging" option enabled).