### PR TITLE
fix: remove duplicate NPM dependency group

### DIFF
--- a/.github/workflows/run-generate-sbom-and-check-licenses.yaml
+++ b/.github/workflows/run-generate-sbom-and-check-licenses.yaml
@@ -128,33 +128,6 @@ jobs:
           name: ${{ inputs.output_sbom_artifact_name }}
           path: .
 
-      # Prepends the dependency group to the dependency name
-      # (as: ".group" + "/" + ".name")
-      #
-      # This is needed due to a bug in Syft that leads 'grant' to not handle
-      # properly dependency groups (e.g., NPM's '@org/pkg-name').
-      #
-      # Example: the NPM package '@types/node' would be reported by 'grant' as
-      # having for name 'node' whereas 'node' and '@types/node` are two
-      # (totally) unrelated packages.
-      #
-      # Ticket: https://github.com/anchore/syft/issues/1202
-      - name: Prepend Dependency Group
-        run: |
-          test -z "${RUNNER_DEBUG+x}" || set -x
-          set -eu
-
-          # When .group is not blank, preprend .group into .name (using a slash (/))
-          jq '
-            (
-              .components[] | select ( .group != "" )
-            ) |= (
-              . + { name: (.group + "/" + .name) }
-            )
-          ' bom.json > fixed.bom.json
-
-          mv fixed.bom.json bom.json
-
       - id: license-analyzer-self
         if: ${{ inputs.is_same_repository }}
         name: Analyze Licenses


### PR DESCRIPTION
This removes the prepended group as the missing groups issue appears to now be resolved (thus the logic is now unnecessary and now causes issues), thus it now leads to the action reporting the groups twice, e.g.,:

```
@algolia/@algolia/cache-common
```

Whereas it should be:

```
@algolia/cache-common
```

(thus points to https://www.npmjs.com/package/@algolia/cache-common)

Duplicate group issue was introduced by #18

---

Example from https://github.com/saleor/apps/pull/2073#issuecomment-3241125272:

<img width="500" height="1035" alt="Screenshot 2025-09-03 at 07 04 14" src="https://github.com/user-attachments/assets/04843b4c-5411-41db-8b5e-ff26f2c80ac0" />


