### PR TITLE
feat: add multi-platform container image builder

### DIFF
--- a/.github/workflows/build-push-image-multi-platform.md
+++ b/.github/workflows/build-push-image-multi-platform.md
@@ -5,7 +5,7 @@
 > It is provided as is and may not fit your use-case, we do not provide support
 > for it and breaking changes may occur without notice.
 
-[./build-push-image-multi-platform.yaml](./build-push-image-multi-platform.yaml) is a
+[build-push-image-multi-platform.yaml](./build-push-image-multi-platform.yaml) is a
 reusable GitHub Workflow that builds and publishes container images for ARM64 and x64
 (AMD64) architectures.
 
@@ -42,11 +42,11 @@ Comparison against the legacy approach:
 
 **Checkout behavior:**
 
-| Input name            | Description                                                              | Type    | Default | Notes                                                                                                                |
-| --------------------- | ------------------------------------------------------------------------ | ------- | ------- | -------------------------------------------------------------------------------------------------------------------- |
-| `checkout-ref`        | Git reference (branch, tag or SHA) to checkout in the source repository. | string  | -       | Uses the defaults to the reference or SHA for the GitHub event (e.g., the commit that was pushed for `push` events.) |
-| `checkout-use-vault`  | Whether to use the vault to fetch repositories.                          | boolean | `false` | Only required when using git submodules that point to private repositories.                                          |
-| `checkout-submodules` | Whether to checkout git submodules.                                      | string  | `false` | Refer to the documentation for the `submodules` field in https://github.com/actions/checkout/.                       |
+| Input name            | Description                                                              | Type    | Default   | Notes                                                                                                                |
+| --------------------- | ------------------------------------------------------------------------ | ------- | --------- | -------------------------------------------------------------------------------------------------------------------- |
+| `checkout-ref`        | Git reference (branch, tag or SHA) to checkout in the source repository. | string  | -         | Uses the defaults to the reference or SHA for the GitHub event (e.g., the commit that was pushed for `push` events.) |
+| `checkout-use-vault`  | Whether to use the vault to fetch repositories.                          | boolean | `false`   | Only required when using git submodules that point to private repositories.                                          |
+| `checkout-submodules` | Whether to checkout git submodules.                                      | string  | `"false"` | Refer to the documentation for the `submodules` field in https://github.com/actions/checkout/.                       |
 
 **GitHub Runner Settings:**
 

--- a/.github/workflows/build-push-image-multi-platform.md
+++ b/.github/workflows/build-push-image-multi-platform.md
@@ -1,0 +1,236 @@
+# Multi-Platform Build & Push for Container Images
+
+> [!WARNING]
+> This workflow is only intended for internal use within the Saleor organization.
+> It is provided as is and may not fit your use-case, we do not provide support
+> for it and breaking changes may occur without notice.
+
+[./build-push-image-multi-platform.yaml](./build-push-image-multi-platform.yaml) is a
+reusable GitHub Workflow that builds and publishes container images for ARM64 and x64
+(AMD64) architectures.
+
+It executes two independent runners to build the two architectures natively on the host
+(ARM64 and x64), and then merges the resulting platform‑specific images into a [image index]
+(which tells `docker` CLI and other container runtimes which image to pull for ARM64,
+and which one for AMD64.)
+
+Key features:
+
+- Native builds on the host (no QEMU emulation).
+- Possibility of using custom GitHub runners (e.g., switching from 2 cores to 4 cores,
+  or using self-hosted runners, or upgrading/downgrading the Ubuntu version, …)
+- Utilizes GitHub cache to further optimize build time.
+- Automatically handles login for the chosen registries (currently only GHCR and AWS ECR
+  are supported.)
+
+Comparison against the legacy approach:
+
+| Metric                      | Legacy Approach                | This Workflow                                       |
+| --------------------------- | ------------------------------ | --------------------------------------------------- |
+| Runner Settings             | 1 runner, 4 cores, Linux, QEMU | 2 runners (parallel build), 2 cores, Linux, no QEMU |
+| Build duration (multi‑arch) | 40 to 60 minutes               | 2 + 2 minutes = 4 min                               |
+| Cost per build              | $0.64 to $0.96/build           | ~$0.032                                             |
+| CI pipeline runtime         | 40~60 min                      | ~2 min                                              |
+
+## Usage
+
+> [!NOTE]
+> The workflow always builds both architectures, the caller cannot an architecture
+> (e.g., **only** building ARM64 isn't supported).
+
+### Inputs
+
+**Checkout behavior:**
+
+| Input name            | Description                                                              | Type    | Default | Notes                                                                                                                |
+| --------------------- | ------------------------------------------------------------------------ | ------- | ------- | -------------------------------------------------------------------------------------------------------------------- |
+| `checkout-ref`        | Git reference (branch, tag or SHA) to checkout in the source repository. | string  | -       | Uses the defaults to the reference or SHA for the GitHub event (e.g., the commit that was pushed for `push` events.) |
+| `checkout-use-vault`  | Whether to use the vault to fetch repositories.                          | boolean | `false` | Only required when using git submodules that point to private repositories.                                          |
+| `checkout-submodules` | Whether to checkout git submodules.                                      | string  | `false` | Refer to the documentation for the `submodules` field in https://github.com/actions/checkout/.                       |
+
+**GitHub Runner Settings:**
+
+| Input name           | Description                                              | Type   | Default          | Notes                                                                                                                                             |
+| -------------------- | -------------------------------------------------------- | ------ | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `amd64-runner-image` | The GitHub runner to use for **x64** image building.     | string | ubuntu-24.04     | Can be a self-hosted runner, a custom, or GitHub-hosted runner (list: https://docs.github.com/en/actions/reference/runners/github-hosted-runners) |
+| `arm64-runner-image` | The GitHub runner to use for **aarch64** image building. | string | ubuntu-24.04-arm | Can be a self-hosted runner, a custom, or GitHub-hosted runner (list: https://docs.github.com/en/actions/reference/runners/github-hosted-runners) |
+
+**Build Settings**:
+
+| Input name            | Description                                                                                                                    | Type   | Default | Notes                                                                |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------ | ------- | -------------------------------------------------------------------- |
+| `oci-full-repository` | Fully‑qualified OCI registry URI (including registry host, namespace and image name), e.g., `oci.example.com/acme/my-project`. | string | –       | **Required** – the _target_ registry where the image will be pushed. |
+| `tags`                | Whitespace-separated list of tags to apply to the final image (e.g. `ghcr.io/org/img:latest ghcr.io/org/img:v1`).              | string | –       | **Required**.                                                        |
+| `build-args`          | List of `--build-arg` arguments to pass to the builder.                                                                        | string | -       | See example below.                                                   |
+
+<details>
+
+<summary>Example usage for `tags` and `build-args`</summary>
+
+```yaml
+# […]
+uses: saleor/saleor-build-workflow/.github/workflows/build.yaml@main
+with:
+tags: |
+  oci.example.com/acme/my-project:v1.0.0
+  oci.example.com/acme/my-project:latest
+build-args: |
+  MY_ARG1=foo
+  MY_ARG2=bar
+```
+
+</details>
+
+**GHCR Settings:**
+
+| Input name    | Description                                                 | Type    | Default | Notes |
+| ------------- | ----------------------------------------------------------- | ------- | ------- | ----- |
+| `enable-ghcr` | Whether to log in to GitHub Container Registry (`ghcr.io`). | boolean | `false` |       |
+
+**ECR Settings:**
+
+| Input name               | Description                                                                           | Type    | Default | Notes                                                      |
+| ------------------------ | ------------------------------------------------------------------------------------- | ------- | ------- | ---------------------------------------------------------- |
+| `enable-aws-ecr`         | Whether to log in to Amazon ECR.                                                      | boolean | `false` |                                                            |
+| `aws-ecr-region`         | AWS region for the ECR registry.                                                      | string  | –       |                                                            |
+| `aws-ecr-role-to-assume` | ARN of the IAM role to assume for cross‑account ECR access.                           | string  | –       | **:warning: Passed as a secret**, see [example](#aws-ecr). |
+| `aws-ecr-registries`     | Comma‑separated list of ECR registry account IDs (e.g., `123456789012,123456789013`). | string  | –       | **:warning: Passed as a secret**, see [example](#aws-ecr). |
+
+**Outputs** (exposed by the `merge-digests` job)
+
+| Output name | Description                                                                                                       |
+| ----------- | ----------------------------------------------------------------------------------------------------------------- |
+| `digest`    | SHA‑256 digest of the final multi‑arch image that was pushed to the target registry, see below for how to use it. |
+
+<details>
+<summary>How to use the <code>digest</code> output</summary>
+
+The workflow exposes the final digest through the `digest` output, then other jobs
+can reference it for further steps (e.g., tests, kubernetes deployment, …)
+
+For example, you could run `pytest` on the image like so:
+
+```yaml
+name: Deploy Main
+on:
+  # NOTE: any trigger is supported (pull_request, release, …)
+  push: [main]
+
+jobs:
+  build_image:
+    uses: saleor/saleor-build-workflow/.github/workflows/build.yaml@main
+    with:
+      oci-full-repository: "ghcr.io/saleor/saleor"
+      tags: |
+        ghcr.io/saleor/saleor:latest
+        ghcr.io/saleor/saleor:1.2.4
+      enable-ghcr: true
+
+  pytest:
+    runs-on: ubuntu-24.04
+    needs: [build_image]
+    timeout-minutes: 5
+
+    env:
+      IMAGE: ghcr.io/saleor/saleor@${{ needs.build_push.outputs.digest }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Run Pytest
+        run: |
+          docker run --rm "$IMAGE" pytest
+```
+
+</details>
+
+### AWS ECR
+
+```yaml
+name: Deploy Main
+on:
+  # NOTE: any trigger is supported (pull_request, release, …)
+  push: [main]
+
+jobs:
+  build-image:
+    uses: saleor/saleor-build-workflow/.github/workflows/build.yaml@main
+    with:
+      oci-full-repository: "123456789012.dkr.ecr.us-east-1.amazonaws.com/saleor/saleor"
+      tags: |
+        123456789012.dkr.ecr.us-east-1.amazonaws.com/saleor/saleor:latest
+        123456789012.dkr.ecr.us-east-1.amazonaws.com/saleor/saleor:1.0.0
+      enable-ghcr: false
+      enable-aws-ecr: true
+    secrets:
+      aws-ecr-role-to-assume: arn:aws:iam::1234567890:role/my-role
+      aws-ecr-registries: "1234567890" # AWS Account ID
+      aws-ecr-region: "us-east-1"
+```
+
+### GitHub Container Registry (GHCR)
+
+```yaml
+name: Deploy Main
+on:
+  # NOTE: any trigger is supported (pull_request, release, …)
+  push: [main]
+
+jobs:
+  push-ghcr:
+    uses: saleor/saleor-build-workflow/.github/workflows/build.yaml@main
+    with:
+      oci-full-repository: "ghcr.io/saleor/saleor"
+      tags: |
+        ghcr.io/saleor/saleor:latest
+        ghcr.io/saleor/saleor:1.2.4
+      enable-ghcr: true
+```
+
+## Architecture
+
+The workflow consists of two phases:
+
+1. Parallel builds (job called "build"):
+   - It runs two runners in parallel that build the image for the ARM64 and x64/AMD64 platforms respectively.
+   - It takes care of login & pushing to OCI registries (AWS ECR and/or GHCR).
+   - It does NOT put any image tag yet, only pushes anonymous images (i.e., no tags, only a manifest ID such as
+     `sha256:3b03f1169a35f1d492a786f588660170c59a8e71e8e69b4c97c66278c0e08431`), this is important in order to be
+     able to create a [image index] (explained below)
+2. Manifest merge (job "merge-digests"):
+   - It executes on a single runner once all parallel builds succeed (thus waits for the build to finish).
+   - It pulls the per‑platform digests (using `actions/download-artifact`).
+   - It then creates a manifest list ([image index]) and pushes it to the target repository.
+     The manifest list/image index will look like this (which is used by docker and other runtimes
+     to determine which digest to pull from the registry such as ECR or GHCR):
+
+     ```json
+     {
+       "schemaVersion": 2,
+       "mediaType": "application/vnd.oci.image.index.v1+json",
+       "manifests": [
+         {
+           "mediaType": "application/vnd.oci.image.manifest.v1+json",
+           "size": 1234,
+           "digest": "sha256:cc292b92ce7f10f2e4f727ecdf4b12528127c51b6ddf6058e213674603190d06",
+           "platform": {
+             "architecture": "amd64",
+             "os": "linux"
+           }
+         },
+         {
+           "mediaType": "application/vnd.oci.image.manifest.v1+json",
+           "size": 1234,
+           "digest": "sha256:5bb21ac469b5e7df4e17899d4aae0adfb430f0f0b336a2242ef1a22d25bd2e53",
+           "platform": {
+             "architecture": "arm64",
+             "os": "linux"
+           }
+         }
+       ]
+     }
+     ```
+
+   - Finally, it exposes the final image digest as a GitHub output (`digest`).
+
+[image index]: https://github.com/opencontainers/image-spec/blob/6519a62d628ec31b5da156de745b516d8850c8e3/image-index.md

--- a/.github/workflows/build-push-image-multi-platform.md
+++ b/.github/workflows/build-push-image-multi-platform.md
@@ -35,7 +35,7 @@ Comparison against the legacy approach:
 ## Usage
 
 > [!NOTE]
-> The workflow always builds both architectures, the caller cannot an architecture
+> The workflow always builds both architectures, the caller cannot skip one
 > (e.g., **only** building ARM64 isn't supported).
 
 ### Inputs
@@ -47,6 +47,13 @@ Comparison against the legacy approach:
 | `checkout-ref`        | Git reference (branch, tag or SHA) to checkout in the source repository. | string  | -         | Uses the defaults to the reference or SHA for the GitHub event (e.g., the commit that was pushed for `push` events.) |
 | `checkout-use-vault`  | Whether to use the vault to fetch repositories.                          | boolean | `false`   | Only required when using git submodules that point to private repositories.                                          |
 | `checkout-submodules` | Whether to checkout git submodules.                                      | string  | `"false"` | Refer to the documentation for the `submodules` field in https://github.com/actions/checkout/.                       |
+
+Secrets (**only** required when passing `checkout-use-vault: true`):
+
+| Input name           | Description                                                                                     | Type   | Default | Notes                                         |
+| -------------------- | ----------------------------------------------------------------------------------------------- | ------ | ------- | --------------------------------------------- |
+| `checkout-vault-url` | The URL to the vault to use to checkout the code; used for downloading submodules.              | string | -       | Only required when `checkout-use-vault: true` |
+| `checkout-vault-jwt` | The JWT for unlocking the vault in order to checkout the code; used for downloading submodules. | string | -       | Only required when `checkout-use-vault: true` |
 
 **GitHub Runner Settings:**
 
@@ -65,7 +72,7 @@ Comparison against the legacy approach:
 
 <details>
 
-<summary>Example usage for `tags` and `build-args`</summary>
+<summary>Example usage for <code>tags</code> and <code>build-args</code></summary>
 
 ```yaml
 # […]

--- a/.github/workflows/build-push-image-multi-platform.md
+++ b/.github/workflows/build-push-image-multi-platform.md
@@ -28,8 +28,8 @@ Comparison against the legacy approach:
 | Metric                      | Legacy Approach                | This Workflow                                       |
 | --------------------------- | ------------------------------ | --------------------------------------------------- |
 | Runner Settings             | 1 runner, 4 cores, Linux, QEMU | 2 runners (parallel build), 2 cores, Linux, no QEMU |
-| Build duration (multi‑arch) | 40 to 60 minutes               | 2 + 2 minutes = 4 min                               |
-| Cost per build              | $0.64 to $0.96/build           | ~$0.032                                             |
+| Build duration (multi‑arch) | 40 to 60 minutes               | 2 minutes                                           |
+| Cost per build              | $0.64 to $0.96/build           | ~$0.032 (2 + 2 minutes, parallel build)             |
 | CI pipeline runtime         | 40~60 min                      | ~2 min                                              |
 
 ## Usage

--- a/.github/workflows/build-push-image-multi-platform.yaml
+++ b/.github/workflows/build-push-image-multi-platform.yaml
@@ -1,0 +1,281 @@
+# Builds and push a container image for ARM64 & AMD64 using native runners (no QEMU).
+name: Build and Push Container Image
+
+on:
+  workflow_call:
+    inputs:
+      checkout-ref:
+        type: string
+        required: true
+        description: >-
+          The project's branch, tag or SHA to checkout.
+      checkout-use-vault:
+        type: boolean
+        description: >-
+          Whether to use the vault to fetch repositories. May be needed when passing
+          'checkout-submodules' input.
+      checkout-submodules:
+        type: string
+        default: ""
+        description: >-
+          Whether to checkout submodules, refer to https://github.com/actions/checkout/
+      # ======================
+      # GitHub Runner Settings
+      # ======================
+      amd64-runner-image:
+        type: string
+        default: ubuntu-24.04
+        description: >-
+          The GitHub runner to use for x64 image building.
+          Can be a self-hosted runner, a custom, or GitHub-hosted runner
+          (list: https://docs.github.com/en/actions/reference/runners/github-hosted-runners)
+      arm64-runner-image:
+        type: string
+        default: ubuntu-24.04-arm
+        description: >-
+          The GitHub runner to use for aarch64 image building.
+          Can be a self-hosted runner, a custom, or GitHub-hosted runner
+          (list: https://docs.github.com/en/actions/reference/runners/github-hosted-runners)
+      # ==============
+      # Build Settings
+      # ==============
+      oci-full-repository:
+        type: string
+        required: true
+        description: >-
+          The repository name, must include the OCI repository hostname, and the repository.
+
+          Example VALID value:
+            oci.example.com/acme/my-project
+
+          Invalid:
+            - acme/my-project (missing hostname)
+            - oci.example.com (missing repository name)
+      tags:
+        type: string
+        required: true
+        description: >-
+          List of tags to use to publish the image (whitespace seperated), must include the hostname.
+
+          Example:
+            tags: |
+              oci.example.com/acme/my-project:v1.0.0
+              oci.example.com/acme/my-project:latest
+      build-args:
+        type: string
+        description: >-
+          List of `--build-arg` arguments to pass to the builder.
+
+          Example:
+            build-args: |
+              MY_ARG1=foo
+              MY_ARG2=bar
+      labels:
+        type: string
+        description: List of labels to add to the final image.
+      # ================
+      # Publish Settings
+      # ================
+      enable-ghcr:
+        type: boolean
+        description: >-
+          If enabled, it will push to GHCR (GitHub Container Repository).
+      enable-aws-ecr:
+        type: boolean
+        description: >-
+          If enabled, it will push to AWS ECR.
+
+          Requires the following settings:
+          - aws-ecr-role-to-assume (secret)
+          - aws-ecr-registries (secret)
+          - aws-ecr-region
+      aws-ecr-region:
+        type: string
+        description: >-
+          The AWS region where to push.
+
+    secrets:
+      checkout-vault-url:
+        description: >-
+          The URL to the vault to use to checkout the code; used for downloading
+          submodules. Refer to https://github.com/actions/checkout/.
+      checkout-vault-jwt:
+        description: >-
+          The JWT for unlocking the vault in order to checkout the code; used for downloading
+          submodules. Refer to https://github.com/actions/checkout/.
+      aws-ecr-role-to-assume:
+        description: >-
+          The IAM role ARN to assume (to push to ECR).
+      aws-ecr-registries:
+        description: >-
+          The list of AWS accounts associated with a AWS ECR registry.
+
+          Example:
+            aws-ecr-registries: "123456789012,998877665544"
+
+permissions: {}
+
+jobs:
+  build:
+    name: Build (${{ matrix.runner-image }})
+    runs-on: ${{ matrix.runner-image }}
+
+    strategy:
+      matrix:
+        runner-image:
+          - ${{ inputs.amd64-runner-image }}
+          - ${{ inputs.arm64-runner-image }}
+
+    permissions:
+      id-token: write # Needed for AWS login
+      packages: write # Needed for GHCR login
+      contents: read
+
+    steps:
+      - id: get-token
+        name: Get Checkout Token
+        if: ${{ inputs.checkout-use-vault }}
+        env:
+          VAULT_URL: ${{ secrets.checkout-vault-url }}
+          VAULT_JWT: ${{ secrets.checkout-vault-jwt }}
+        run: |
+          token=$(
+            curl --request GET --url "$VAULT_URL" --header "Authorization: JWT $VAULT_JWT" | jq -r .token
+          )
+          echo "::add-mask::$token"
+          echo "token=${token}" >> "$GITHUB_OUTPUT"
+
+      # Clone the invoker's repository.
+      - name: Checkout Caller's Code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: ${{ inputs.checkout-ref }}
+          token: ${{ steps.get-token.outputs.token || github.token }}
+          submodules: ${{ inputs.checkout-submodules }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        with:
+          install: true
+
+      - if: ${{ inputs.enable-aws-ecr }}
+        name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: ${{ secrets.aws-ecr-role-to-assume }}
+          aws-region: ${{ inputs.aws-ecr-region }}
+
+      - if: ${{ inputs.enable-aws-ecr }}
+        name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+        with:
+          registries: ${{ secrets.aws-ecr-registries }}
+
+      - if: ${{ inputs.enable-ghcr }}
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        id: build
+        with:
+          context: .
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # We set `push-by-digest=true` thus we cannot put any tag and thus we use
+          # the container repository name instead (ghcr.io/saleor/saleor)
+          # (we cannot push both by tags and by digest, only one or the other)
+          tags: ${{ inputs.oci-full-repository }}
+          labels: ${{ inputs.labels }}
+          build-args: ${{ inputs.build-args }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true,oci-mediatypes=true
+
+      - name: Export digest
+        env:
+          BUILD_DIGEST: ${{ steps.build.outputs.digest }}
+          RUNNER_TEMP: ${{ runner.temp }}
+        run: |
+          mkdir -p "$RUNNER_TEMP"/digests
+          touch "$RUNNER_TEMP/digests/${BUILD_DIGEST#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: digests-${{ matrix.runner-image }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Merges all built platforms into a single manifest
+  merge-digests:
+    needs: build
+
+    runs-on: ubuntu-24.04
+
+    permissions:
+      id-token: write # Needed for AWS login
+      packages: write # Needed for GHCR login
+      contents: none
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        with:
+          install: true
+
+      - if: ${{ inputs.enable-aws-ecr }}
+        name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: ${{ secrets.aws-ecr-role-to-assume }}
+          aws-region: ${{ inputs.aws-ecr-region }}
+
+      - if: ${{ inputs.enable-aws-ecr }}
+        name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
+        with:
+          registries: ${{ secrets.aws-ecr-registries }}
+
+      - name: Download digests
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - if: ${{ inputs.enable-ghcr }}
+        name: Login to GitHub Container Registry
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          REPO: ${{ inputs.oci-full-repository }}
+          IMAGE_TAGS: ${{ inputs.tags }}
+        run: |
+          set -u
+          buildx_args=( )
+
+          # Build a list of --tag=XXX based on the user-provided tag list (${{ inputs.tags }})
+          # NOTE: `read` will return 1 on EOF, hence the `|| true`
+          IFS=, read -r -a tag_list <<< "$IMAGE_TAGS" || true
+          for tag in "${tag_list[@]}"; do
+            buildx_args+=( --tag="$tag" )
+          done
+
+          # Build the list of digests to include inside the final image
+          for digest in *; do
+            buildx_args+=( "$REPO@sha256:$digest" )
+          done
+
+          echo "Creating image with args: ${buildx_args[*]}" >&2
+          docker buildx imagetools create "${buildx_args[@]}"

--- a/.github/workflows/build-push-image-multi-platform.yaml
+++ b/.github/workflows/build-push-image-multi-platform.yaml
@@ -112,6 +112,10 @@ on:
 
           Example:
             aws-ecr-registries: "123456789012,998877665544"
+    outputs:
+      digest:
+        description: The manifest list's digest (e.g., 'sha256:7007b387ccd52bd42a050f2e8020e56e64622c9269bf7bbe257b326fe99daf19')
+        value: ${{ jobs.merge-digests.outputs.digest }}
 
 permissions: {}
 
@@ -222,6 +226,9 @@ jobs:
       packages: write # Needed for GHCR login
       contents: none
 
+    outputs:
+      digest: ${{ steps.push-manifest.outputs.digest }}
+
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
@@ -257,6 +264,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create manifest list and push
+        id: push-manifest
         working-directory: ${{ runner.temp }}/digests
         env:
           REPO: ${{ inputs.oci-full-repository }}
@@ -265,7 +273,7 @@ jobs:
           set -u
           buildx_args=( )
 
-          # Build a list of --tag=XXX based on the user-provided tag list (${{ inputs.tags }})
+          # Build a list of --tag=XXX based on the user-provided tag list
           # NOTE: `read` will return 1 on EOF, hence the `|| true`
           IFS=, read -r -a tag_list <<< "$IMAGE_TAGS" || true
           for tag in "${tag_list[@]}"; do
@@ -279,3 +287,13 @@ jobs:
 
           echo "Creating image with args: ${buildx_args[*]}" >&2
           docker buildx imagetools create "${buildx_args[@]}"
+
+          # Retrieves the image's digest, useful for importing the image for example.
+          # NOTE: running 'inspect' is only necessary until this issue is solved: https://github.com/docker/buildx/issues/2407
+          # Example output: sha256:08602e7340970e92bde5e0a2e887c1fde4d9ae753d1e05efb4c8ef3b609f97f1
+          echo "Retrieving image digest"
+          digest=$(
+            docker buildx imagetools inspect "${tag_list[0]}" --format '{{ json .Manifest.Digest }}' \
+            | jq -r .
+          )
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-push-image-multi-platform.yaml
+++ b/.github/workflows/build-push-image-multi-platform.yaml
@@ -270,7 +270,7 @@ jobs:
           REPO: ${{ inputs.oci-full-repository }}
           IMAGE_TAGS: ${{ inputs.tags }}
         run: |
-          set -u
+          set -u -o pipefail
           buildx_args=( )
 
           # Build a list of --tag=XXX based on the user-provided tag list

--- a/README.md
+++ b/README.md
@@ -9,17 +9,16 @@ This is a collection of GitHub Actions created and used by Saleor internally.
 ## Actions
 
 | Name                                           | Description                                                       |
-|------------------------------------------------|-------------------------------------------------------------------|
+| ---------------------------------------------- | ----------------------------------------------------------------- |
 | [sbom-generator](sbom-generator)               | Generates a CycloneDX SBOM with license fetching enabled.         |
 | [grant-license-checker](grant-license-checker) | Generates a license usage report of a given SBOM using [`grant`]. |
 
-
 ## Reusable Workflows
 
-| Name                                                               | Description                                                                        |
-|--------------------------------------------------------------------|------------------------------------------------------------------------------------|
-| [run-license-check.yaml](.github/workflows/run-license-check.yaml) | Summarizes the list of licenses as a pull request comment (by generating an SBOM.) |
-
+| Name                                                                                           | Description                                                                                                                                                               |
+| ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [run-license-check.yaml](.github/workflows/run-license-check.yaml)                             | Summarizes the list of licenses as a pull request comment (by generating an SBOM.)                                                                                        |
+| [build-push-image-multi-platform.yaml](.github/workflows/build-push-image-multi-platform.yaml) | Blazing fast building for multi-arch OCI images (ARM64 and AMD64 only). See [documentation](/.github/workflows/build-push-image-multi-platform.md) for usage information. |
 
 ## Development
 


### PR DESCRIPTION
This adds a new re-usable workflow that builds an image natively (ARM64, AMD64) and pushes it into a given OCI repository

It executes two independent runners to build the two architectures natively on the host
(ARM64 and x64), and then merges the resulting platform‑specific images into a [image index]
(which tells `docker` CLI and other container runtimes which image to pull for ARM64,
and which one for AMD64.)

Key features:

- Native builds on the host (no QEMU emulation).
- Possibility of using custom GitHub runners (e.g., switching from 2 cores to 4 cores,
  or using self-hosted runners, or upgrading/downgrading the Ubuntu version, …)
- Utilizes GitHub cache to further optimize build time.
- Automatically handles login for the chosen registries (currently only GHCR and AWS ECR
  are supported.)

Comparison against the legacy approach:

| Metric                      | Legacy Approach                | This Workflow                                       |
| --------------------------- | ------------------------------ | --------------------------------------------------- |
| Runner Settings             | 1 runner, 4 cores, Linux, QEMU | 2 runners (parallel build), 2 cores, Linux, no QEMU |
| Build duration (multi‑arch) | 40 to 60 minutes               | 2 minutes                                           |
| Cost per build              | $0.64 to $0.96/build           | ~$0.032 (2 + 2 minutes, parallel build)             |
| CI pipeline runtime         | 40~60 min                      | ~2 min                                              |

Full documentation: https://github.com/saleor/saleor-internal-actions/blob/0c75c318918b22642bf0c471f18e4a874c16f187/.github/workflows/build-push-image-multi-platform.md

> [!NOTE]
> Technical details are at the [bottom of the page](https://github.com/saleor/saleor-internal-actions/blob/0c75c318918b22642bf0c471f18e4a874c16f187/.github/workflows/build-push-image-multi-platform.md#architecture)