### PR TITLE
feat: add custom build context for build-push-image

### DIFF
--- a/.github/workflows/build-push-image-multi-platform.md
+++ b/.github/workflows/build-push-image-multi-platform.md
@@ -64,11 +64,13 @@ Secrets (**only** required when passing `checkout-use-vault: true`):
 
 **Build Settings**:
 
-| Input name            | Description                                                                                                                    | Type   | Default | Notes                                                                |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------ | ------- | -------------------------------------------------------------------- |
-| `oci-full-repository` | Fully‑qualified OCI registry URI (including registry host, namespace and image name), e.g., `oci.example.com/acme/my-project`. | string | –       | **Required** – the _target_ registry where the image will be pushed. |
-| `tags`                | Whitespace-separated list of tags to apply to the final image (e.g. `ghcr.io/org/img:latest ghcr.io/org/img:v1`).              | string | –       | **Required**.                                                        |
-| `build-args`          | List of `--build-arg` arguments to pass to the builder.                                                                        | string | -       | See example below.                                                   |
+| Input name            | Description                                                                                                                    | Type   | Default      | Notes                                                                |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------ | ------------ | -------------------------------------------------------------------- |
+| `context-path`        | The path to use as the build context.                                                                                          | string | ./           |                                                                      |
+| `dockerfile-path`     | The path to the Dockerfile to build.                                                                                           | string | ./Dockerfile |                                                                      |
+| `oci-full-repository` | Fully‑qualified OCI registry URI (including registry host, namespace and image name), e.g., `oci.example.com/acme/my-project`. | string | –            | **Required** – the _target_ registry where the image will be pushed. |
+| `tags`                | Whitespace-separated list of tags to apply to the final image (e.g. `ghcr.io/org/img:latest ghcr.io/org/img:v1`).              | string | –            | **Required**.                                                        |
+| `build-args`          | List of `--build-arg` arguments to pass to the builder.                                                                        | string | -            | See example below.                                                   |
 
 <details>
 

--- a/.github/workflows/build-push-image-multi-platform.md
+++ b/.github/workflows/build-push-image-multi-platform.md
@@ -64,13 +64,14 @@ Secrets (**only** required when passing `checkout-use-vault: true`):
 
 **Build Settings**:
 
-| Input name            | Description                                                                                                                    | Type   | Default      | Notes                                                                |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------ | ------------ | -------------------------------------------------------------------- |
-| `context-path`        | The path to use as the build context.                                                                                          | string | ./           |                                                                      |
-| `dockerfile-path`     | The path to the Dockerfile to build.                                                                                           | string | ./Dockerfile |                                                                      |
-| `oci-full-repository` | Fully‑qualified OCI registry URI (including registry host, namespace and image name), e.g., `oci.example.com/acme/my-project`. | string | –            | **Required** – the _target_ registry where the image will be pushed. |
-| `tags`                | Whitespace-separated list of tags to apply to the final image (e.g. `ghcr.io/org/img:latest ghcr.io/org/img:v1`).              | string | –            | **Required**.                                                        |
-| `build-args`          | List of `--build-arg` arguments to pass to the builder.                                                                        | string | -            | See example below.                                                   |
+| Input name             | Description                                                                                                                    | Type    | Default        | Notes                                                                |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------- | -------------- | -------------------------------------------------------------------- |
+| `context-path`         | The path to use as the build context.                                                                                          | string  | `./`           |                                                                      |
+| `dockerfile-path`      | The path to the Dockerfile to build.                                                                                           | string  | `./Dockerfile` |                                                                      |
+| `docker-build-summary` | Whether to generate a build summary (https://docs.docker.com/build/ci/github-actions/build-summary/)                           | boolean | `true`         |                                                                      |
+| `oci-full-repository`  | Fully‑qualified OCI registry URI (including registry host, namespace and image name), e.g., `oci.example.com/acme/my-project`. | string  | –              | **Required** – the _target_ registry where the image will be pushed. |
+| `tags`                 | Whitespace-separated list of tags to apply to the final image (e.g. `ghcr.io/org/img:latest ghcr.io/org/img:v1`).              | string  | –              | **Required**.                                                        |
+| `build-args`           | List of `--build-arg` arguments to pass to the builder.                                                                        | string  | -              | See example below.                                                   |
 
 <details>
 

--- a/.github/workflows/build-push-image-multi-platform.yaml
+++ b/.github/workflows/build-push-image-multi-platform.yaml
@@ -39,6 +39,18 @@ on:
       # ==============
       # Build Settings
       # ==============
+      context-path:
+        type: string
+        default: ./
+        description: >-
+          The directory that should be used as the context for the `docker build <context>`
+          command.
+      dockerfile-path:
+        type: string
+        default: ./Dockerfile
+        description: >-
+          The path to the Dockerfile to use (must be inside the context), equivalent
+          to `docker build -f ./my-path/Dockerfile ./`
       oci-full-repository:
         type: string
         required: true
@@ -187,7 +199,8 @@ jobs:
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         id: build
         with:
-          context: .
+          context: ${{ inputs.context-path }}
+          file: ${{ inputs.dockerfile-path }}
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build-push-image-multi-platform.yaml
+++ b/.github/workflows/build-push-image-multi-platform.yaml
@@ -51,6 +51,11 @@ on:
         description: >-
           The path to the Dockerfile to use (must be inside the context), equivalent
           to `docker build -f ./my-path/Dockerfile ./`
+      docker-build-summary:
+        type: boolean
+        default: true
+        description: >-
+          Whether to generate a build summary (https://docs.docker.com/build/ci/github-actions/build-summary/)
       oci-full-repository:
         type: string
         required: true
@@ -198,6 +203,8 @@ jobs:
       - name: Build and Push
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         id: build
+        env:
+          DOCKER_BUILD_SUMMARY: ${{ inputs.docker-build-summary }}
         with:
           context: ${{ inputs.context-path }}
           file: ${{ inputs.dockerfile-path }}


### PR DESCRIPTION
This adds 2 new inputs for the `build-push-image-multi-platform` workflow:
- dockerfile-path: the path to the dockerfile
- context-path: the path for the build context

This allows to build more complex repositories (such as repositories with containing multiple Dockerfile variants or projects)