### PR TITLE
feat(build-push): add possibility of using secrets in OCI registry

### DIFF
--- a/.github/workflows/build-push-image-multi-platform.md
+++ b/.github/workflows/build-push-image-multi-platform.md
@@ -64,15 +64,15 @@ Secrets (**only** required when passing `checkout-use-vault: true`):
 
 **Build Settings**:
 
-| Input name             | Description                                                                                                                    | Type    | Default        | Notes                                                                |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------- | -------------- | -------------------------------------------------------------------- |
-| `context-path`         | The path to use as the build context.                                                                                          | string  | `./`           |                                                                      |
-| `dockerfile-path`      | The path to the Dockerfile to build.                                                                                           | string  | `./Dockerfile` |                                                                      |
-| `target`               | The build stage to use in the Dockerfile (same as `docker build --target <TARGET>`)                                            | string  | -              |                                                                      |
-| `docker-build-summary` | Whether to generate a build summary (https://docs.docker.com/build/ci/github-actions/build-summary/)                           | boolean | `true`         |                                                                      |
-| `oci-full-repository`  | Fully‑qualified OCI registry URI (including registry host, namespace and image name), e.g., `oci.example.com/acme/my-project`. | string  | –              | **Required** – the _target_ registry where the image will be pushed. |
-| `tags`                 | Whitespace-separated list of tags to apply to the final image (e.g. `ghcr.io/org/img:latest ghcr.io/org/img:v1`).              | string  | –              | **Required**.                                                        |
-| `build-args`           | List of `--build-arg` arguments to pass to the builder.                                                                        | string  | -              | See example below.                                                   |
+| Input name             | Description                                                                                                                    | Type    | Default        | Notes                                                                                                                |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------- | -------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `context-path`         | The path to use as the build context.                                                                                          | string  | `./`           |                                                                                                                      |
+| `dockerfile-path`      | The path to the Dockerfile to build.                                                                                           | string  | `./Dockerfile` |                                                                                                                      |
+| `target`               | The build stage to use in the Dockerfile (same as `docker build --target <TARGET>`)                                            | string  | -              |                                                                                                                      |
+| `docker-build-summary` | Whether to generate a build summary (https://docs.docker.com/build/ci/github-actions/build-summary/)                           | boolean | `true`         |                                                                                                                      |
+| `oci-full-repository`  | Fully‑qualified OCI registry URI (including registry host, namespace and image name), e.g., `oci.example.com/acme/my-project`. | string  | –              | **Required** – the _target_ registry where the image will be pushed. Can be passed in the `with` or `secrets` block. |
+| `tags`                 | Comma or newline-separated list of tags to apply to the final image (e.g. `latest,v1,v1.0.1`).                                 | string  | –              | **Required**.                                                                                                        |
+| `build-args`           | List of `--build-arg` arguments to pass to the builder.                                                                        | string  | -              | See example below.                                                                                                   |
 
 <details>
 
@@ -82,9 +82,13 @@ Secrets (**only** required when passing `checkout-use-vault: true`):
 # […]
 uses: saleor/saleor-build-workflow/.github/workflows/build.yaml@main
 with:
-tags: |
-  oci.example.com/acme/my-project:v1.0.0
-  oci.example.com/acme/my-project:latest
+  oci-full-repository: oci.example.com/acme/my-project
+  tags: |
+    v1.0.0
+    latest
+# Uncomment if you want to use a secret instead
+# secrets:
+#   oci-full-repository: oci.example.com/acme/my-project
 build-args: |
   MY_ARG1=foo
   MY_ARG2=bar
@@ -133,8 +137,8 @@ jobs:
     with:
       oci-full-repository: "ghcr.io/saleor/saleor"
       tags: |
-        ghcr.io/saleor/saleor:latest
-        ghcr.io/saleor/saleor:1.2.4
+        latest
+        1.2.4
       enable-ghcr: true
 
   pytest:
@@ -169,8 +173,8 @@ jobs:
     with:
       oci-full-repository: "123456789012.dkr.ecr.us-east-1.amazonaws.com/saleor/saleor"
       tags: |
-        123456789012.dkr.ecr.us-east-1.amazonaws.com/saleor/saleor:latest
-        123456789012.dkr.ecr.us-east-1.amazonaws.com/saleor/saleor:1.0.0
+        latest
+        1.0.0
       enable-ghcr: false
       enable-aws-ecr: true
     secrets:
@@ -193,8 +197,8 @@ jobs:
     with:
       oci-full-repository: "ghcr.io/saleor/saleor"
       tags: |
-        ghcr.io/saleor/saleor:latest
-        ghcr.io/saleor/saleor:1.2.4
+        latest
+        1.2.4
       enable-ghcr: true
 ```
 

--- a/.github/workflows/build-push-image-multi-platform.yaml
+++ b/.github/workflows/build-push-image-multi-platform.yaml
@@ -65,7 +65,6 @@ on:
           Whether to generate a build summary (https://docs.docker.com/build/ci/github-actions/build-summary/)
       oci-full-repository:
         type: string
-        required: true
         description: >-
           The repository name, must include the OCI repository hostname, and the repository.
 
@@ -79,9 +78,15 @@ on:
         type: string
         required: true
         description: >-
-          List of tags to use to publish the image (whitespace seperated), must include the hostname.
+          List of tags to use to publish the image (newline or comma separated),
+          can include or omit the registry's hostname.
 
-          Example:
+          Example without the registry (will use the value from 'oci-full-repository'):
+            tags: |
+              v1.0.0
+              latest
+
+          Example with the registry:
             tags: |
               oci.example.com/acme/my-project:v1.0.0
               oci.example.com/acme/my-project:latest
@@ -136,6 +141,16 @@ on:
 
           Example:
             aws-ecr-registries: "123456789012,998877665544"
+      oci-full-repository:
+        description: >-
+          The repository name, must include the OCI repository hostname, and the repository.
+
+          Example VALID value:
+            oci.example.com/acme/my-project
+
+          Invalid:
+            - acme/my-project (missing hostname)
+            - oci.example.com (missing repository name)
     outputs:
       digest:
         description: The manifest list's digest (e.g., 'sha256:7007b387ccd52bd42a050f2e8020e56e64622c9269bf7bbe257b326fe99daf19')
@@ -160,6 +175,22 @@ jobs:
       contents: read
 
     steps:
+      - name: Validate Inputs
+        env:
+          INPUT_OCI_REPO: ${{ inputs.oci-full-repository }}
+          SECRET_OCI_REPO: ${{ secrets.oci-full-repository }}
+        run: |
+          set -u -o pipefail
+
+          if [[ -z "$INPUT_OCI_REPO" ]] && [[ -z "$SECRET_OCI_REPO" ]]; then
+            {
+              echo "Missing required input: oci-full-repository must be provided."
+              echo "For more information, refer to the documentation under" \
+                    ".github/workflows/build-push-image-multi-platform.md"
+            } >&2
+            exit 1
+          fi
+
       - id: get-token
         name: Get Checkout Token
         if: ${{ inputs.checkout-use-vault }}
@@ -222,7 +253,7 @@ jobs:
           # We set `push-by-digest=true` thus we cannot put any tag and thus we use
           # the container repository name instead (ghcr.io/saleor/saleor)
           # (we cannot push both by tags and by digest, only one or the other)
-          tags: ${{ inputs.oci-full-repository }}
+          tags: ${{ inputs.oci-full-repository || secrets.oci-full-repository }}
           labels: ${{ inputs.labels }}
           build-args: ${{ inputs.build-args }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true,oci-mediatypes=true
@@ -295,25 +326,35 @@ jobs:
         id: push-manifest
         working-directory: ${{ runner.temp }}/digests
         env:
-          REPO: ${{ inputs.oci-full-repository }}
+          REPO: ${{ inputs.oci-full-repository || secrets.oci-full-repository }}
           IMAGE_TAGS: ${{ inputs.tags }}
         run: |
           set -u -o pipefail
           buildx_args=( )
 
+          # Normalize comma-separated tag list into newline separated list
+          IMAGE_TAGS=$(echo "$IMAGE_TAGS" | tr ',' $'\n')
+
           # Build a list of --tag=XXX based on the user-provided tag list
-          # NOTE: `read` will return 1 on EOF, hence the `|| true`
-          IFS=, read -r -a tag_list <<< "$IMAGE_TAGS" || true
-          for tag in "${tag_list[@]}"; do
+          mapfile -t tag_list <<<"$IMAGE_TAGS"
+          for i in "${!tag_list[@]}"; do
+            tag="${tag_list[$i]}"
+
+            # If tag doesn't specify the OCI repo, then we add it
+            if [[ "$tag" != "$REPO"* ]]; then
+              tag="$REPO":"$tag"
+              tag_list[i]="$tag"
+            fi
+
             buildx_args+=( --tag="$tag" )
           done
 
           # Build the list of digests to include inside the final image
           for digest in *; do
+            echo "Creating image for digest: ${digest}" >&2
             buildx_args+=( "$REPO@sha256:$digest" )
           done
 
-          echo "Creating image with args: ${buildx_args[*]}" >&2
           docker buildx imagetools create "${buildx_args[@]}"
 
           # Retrieves the image's digest, useful for importing the image for example.

--- a/.github/workflows/build-push-image-multi-platform.yaml
+++ b/.github/workflows/build-push-image-multi-platform.yaml
@@ -74,6 +74,11 @@ on:
           Invalid:
             - acme/my-project (missing hostname)
             - oci.example.com (missing repository name)
+
+          Examples:
+            - AWS ECR: 123456789012.dkr.ecr.us-east-1.amazonaws.com/my-repo/my-image-name
+            - GHCR: ghcr.io/my-organization/my-repository-name
+            - Docker Hub: docker.io/my-organization/my-repository-name
       tags:
         type: string
         required: true
@@ -86,10 +91,11 @@ on:
               v1.0.0
               latest
 
-          Example with the registry:
+          You can also (optionally) provide the registry and repository name:
             tags: |
-              oci.example.com/acme/my-project:v1.0.0
-              oci.example.com/acme/my-project:latest
+              123456789012.dkr.ecr.us-east-1.amazonaws.com/my-repo/my-image-name:v1.0.0
+              ghcr.io/my-organization/my-repository-name:v1.0.0
+              docker.io/my-organization/my-repository-name:v1.0.0
       build-args:
         type: string
         description: >-
@@ -151,6 +157,11 @@ on:
           Invalid:
             - acme/my-project (missing hostname)
             - oci.example.com (missing repository name)
+
+          Examples:
+            - AWS ECR: 123456789012.dkr.ecr.us-east-1.amazonaws.com/my-repo/my-image-name
+            - GHCR: ghcr.io/my-organization/my-repository-name
+            - Docker Hub: docker.io/my-organization/my-repository-name
     outputs:
       digest:
         description: The manifest list's digest (e.g., 'sha256:7007b387ccd52bd42a050f2e8020e56e64622c9269bf7bbe257b326fe99daf19')

--- a/.github/workflows/build-push-image-multi-platform.yaml
+++ b/.github/workflows/build-push-image-multi-platform.yaml
@@ -78,7 +78,7 @@ on:
           Examples:
             - AWS ECR: 123456789012.dkr.ecr.us-east-1.amazonaws.com/my-repo/my-image-name
             - GHCR: ghcr.io/my-organization/my-repository-name
-            - Docker Hub: docker.io/my-organization/my-repository-name
+            - Docker Hub: docker.io/my-organization/my-repository-name (unsupported currently, no auth step)
       tags:
         type: string
         required: true
@@ -161,7 +161,7 @@ on:
           Examples:
             - AWS ECR: 123456789012.dkr.ecr.us-east-1.amazonaws.com/my-repo/my-image-name
             - GHCR: ghcr.io/my-organization/my-repository-name
-            - Docker Hub: docker.io/my-organization/my-repository-name
+            - Docker Hub: docker.io/my-organization/my-repository-name (unsupported currently, no auth step)
     outputs:
       digest:
         description: The manifest list's digest (e.g., 'sha256:7007b387ccd52bd42a050f2e8020e56e64622c9269bf7bbe257b326fe99daf19')


### PR DESCRIPTION
Changes:
- Made it possible to pass the input `oci-full-repository` either as a secret or non-secret input. This is especially useful for AWS ECR.
- Made it optional to provide the registry & repo name in `tags` - this avoids having to pass secrets in the `tags` input, and removes the redundancy.

  Note: this is optional for backward compatibility, we may start requiring to only provide the tag without the OCI repo later on.
- Fixed newline seperated tags not being pushed - only the 1st tag would be pushed and the rest would be ignored.

  Before:

  ```yaml
  tags: |
    v1      # <-- This was pushed
    v1.0    # <-- Bug: this was getting skipped
    v1.0.0  # <-- Bug: skipped too
  ```

Changes are major however they are backward compatible. During testing I didn't find any issues with supporting existing usages.