### PR TITLE
release: v1.6.0

### DIFF
--- a/.github/workflows/run-generate-sbom-and-check-licenses.yaml
+++ b/.github/workflows/run-generate-sbom-and-check-licenses.yaml
@@ -85,7 +85,7 @@ jobs:
       # reusable workflows.
       - if: ${{ !inputs.is_same_repository }}
         name: Generate SBOM
-        uses: saleor/saleor-internal-actions/sbom-generator@v1.5.2
+        uses: saleor/saleor-internal-actions/sbom-generator@v1.6.0
         with:
           sbom_path: "./bom.json"
           ecosystems: ${{ inputs.ecosystems }}
@@ -140,7 +140,7 @@ jobs:
       - id: license-analyzer-workflow-call
         if: ${{ !inputs.is_same_repository }}
         name: Analyze Licenses
-        uses: saleor/saleor-internal-actions/grant-license-checker@v1.5.2
+        uses: saleor/saleor-internal-actions/grant-license-checker@v1.6.0
         with:
           rules: ${{ inputs.rules }}
           sbom_path: ./bom.json


### PR DESCRIPTION
Changes (via 986ef91f10ba2223653189602ee759db7a35215f):
- Feature: made it possible to pass the input `oci-full-repository` either as a secret or non-secret input. This is especially useful for AWS ECR.
- Feature: made it optional to provide the registry & repo name in `tags` - this avoids having to pass secrets in the `tags` input, and removes the redundancy.
- Fix: fixed newline seperated tags not being pushed properly.