### PR TITLE
ENG-1156 - Prepare reusable workflow for notifying slack

### DIFF
--- a/.github/workflows/notify-slack.md
+++ b/.github/workflows/notify-slack.md
@@ -1,0 +1,162 @@
+# Notify Slack
+
+> [!WARNING]
+> This workflow is only intended for internal use within the Saleor organization.
+> It is provided as is and may not fit your use-case, we do not provide support
+> for it and breaking changes may occur without notice.
+
+[notify-slack.yaml](./notify-slack.yaml) is a reusable GitHub Workflow for sending
+notifications to Slack using an [incoming webhook]. It wraps the
+[slackapi/slack-github-action] (v2) to provide a consistent interface across all
+Saleor workflows.
+
+The message includes a colored sidebar based on status (green for success, red for
+failure, grey for other), and a body with the author, status, and a link to the
+workflow run.
+
+### Message format - depends on the inputs:
+
+1. When `type: build` is provided:
+    > [repo-name]() | Finished build of **{ref}**
+    >
+    > Author: **username**
+    >
+    > Workflow: [workflow-name]()
+    >
+    > Status: **status**
+    >
+    > [View run logs]()
+
+2. When `type: deployment` is provided:
+    > [repo-name]() | Finished deployment of **{ref}** to **{service}**
+    >
+    > Author: **username**
+    >
+    > Workflow: [workflow-name]()
+    >
+    > Status: **status**
+    >
+    > [View run logs]()
+
+3. When `custom_title:` is provided:
+    > [repo-name]() | {your custom title}
+    >
+    > Author: **username**
+    >
+    > Workflow: [workflow-name]()
+    >
+    > Status: **status**
+    >
+    > [View run logs]()
+
+## Usage
+
+### Inputs
+
+| Input name | Description                                                                  | Type   | Default | Notes                                            |
+| ---------- | ---------------------------------------------------------------------------- | ------ | ------- | ------------------------------------------------ |
+| `custom_title` | Custom title for the notification. Supports Slack mrkdwn.                | string | `""`    | If provided, `type` and `ref` are not required.  |
+| `type`     | The type of notification: `build` or `deployment`.                           | string | `""`    | Required if `custom_title` is not provided.             |
+| `ref`      | The git ref (branch, tag, or SHA) that was built or deployed.                | string | `""`    | Required if `custom_title` is not provided.             |
+| `status`   | The outcome of the workflow. Controls sidebar color (green=success, red=failure, grey=other). | string | -       | **Required**.                                    |
+| `service`  | The target service or environment (e.g., `saleor-v320-sandbox-eu`).          | string | `""`    | Required when `type` is `deployment`.            |
+
+### Secrets
+
+| Secret name         | Description                     | Notes                                                                                                   |
+| ------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `slack-webhook-url` | A Slack incoming webhook URL.   | **Required**. Our "Cloud Deployments" app webhooks can be found [here][cloud-deployments-app-webhooks]. |
+
+### Outputs
+
+| Output name | Description                                           |
+| ----------- | ----------------------------------------------------- |
+| `ok`        | Whether the request completed without errors.         |
+| `response`  | A JSON stringified version of the Slack API response. |
+
+## Examples
+
+### Build notification
+
+```yaml
+name: Build
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - run: make build
+
+  notify:
+    needs: build
+    if: ${{ always() }}
+    uses: saleor/saleor-internal-actions/.github/workflows/notify-slack.yaml@main
+    with:
+      type: build
+      ref: ${{ github.ref_name }}
+      status: ${{ needs.build.result }}
+    secrets:
+      slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+```
+
+### Deployment notification
+
+```yaml
+name: Deploy
+on:
+  workflow_dispatch:
+    inputs:
+      service:
+        required: true
+        type: string
+
+jobs:
+  deploy:
+    runs-on: ubuntu-24.04
+    steps:
+      - run: echo "Deploying..."
+
+  notify:
+    needs: deploy
+    if: ${{ always() }}
+    uses: saleor/saleor-internal-actions/.github/workflows/notify-slack.yaml@main
+    with:
+      type: deployment
+      ref: ${{ github.ref_name }}
+      service: ${{ inputs.service }}
+      status: ${{ needs.deploy.result }}
+    secrets:
+      slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+```
+
+### Custom title notification
+
+```yaml
+name: Custom Notification
+on:
+  workflow_dispatch:
+
+jobs:
+  task:
+    runs-on: ubuntu-24.04
+    steps:
+      - run: echo "Doing something..."
+
+  notify:
+    needs: task
+    if: ${{ always() }}
+    uses: saleor/saleor-internal-actions/.github/workflows/notify-slack.yaml@main
+    with:
+      custom_title: "*Custom task* completed"
+      status: ${{ needs.task.result }}
+    secrets:
+      slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+```
+
+[incoming webhook]: https://api.slack.com/messaging/webhooks
+[slackapi/slack-github-action]: https://github.com/slackapi/slack-github-action
+[cloud-deployments-app-webhooks]: https://api.slack.com/apps/A0A56MD0DHS/incoming-webhooks?

--- a/.github/workflows/notify-slack.md
+++ b/.github/workflows/notify-slack.md
@@ -28,7 +28,7 @@ workflow run.
     > [View run logs]()
 
 2. When `type: deployment` is provided:
-    > [repo-name]() | Finished deployment of **{ref}** to **{service}**
+    > [repo-name]() | **{product}** | Finished deployment of **{ref}** to **{environment}**
     >
     > Author: **username**
     >
@@ -59,7 +59,8 @@ workflow run.
 | `type`     | The type of notification: `build` or `deployment`.                           | string | `""`    | Required if `custom_title` is not provided.             |
 | `ref`      | The git ref (branch, tag, or SHA) that was built or deployed.                | string | `""`    | Required if `custom_title` is not provided.             |
 | `status`   | The outcome of the workflow. Controls sidebar color (green=success, red=failure, grey=other). | string | -       | **Required**.                                    |
-| `service`  | The target service or environment (e.g., `saleor-v320-sandbox-eu`).          | string | `""`    | Required when `type` is `deployment`.            |
+| `product`  | The product being deployed (e.g., `keycloak`, `saleor-multitenant`).         | string | `""`    | Required when `type` is `deployment`.            |
+| `environment` | The target environment (e.g., `prod`, `staging`, `v322-staging`).         | string | `""`    | Required when `type` is `deployment`.            |
 
 ### Secrets
 
@@ -110,7 +111,10 @@ name: Deploy
 on:
   workflow_dispatch:
     inputs:
-      service:
+      product:
+        required: true
+        type: string
+      environment:
         required: true
         type: string
 
@@ -127,7 +131,8 @@ jobs:
     with:
       type: deployment
       ref: ${{ github.ref_name }}
-      service: ${{ inputs.service }}
+      product: ${{ inputs.product }}
+      environment: ${{ inputs.environment }}
       status: ${{ needs.deploy.result }}
     secrets:
       slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/notify-slack.yaml
+++ b/.github/workflows/notify-slack.yaml
@@ -1,0 +1,153 @@
+# Sends a templated notification to Slack using an incoming webhook.
+name: Notify Slack
+
+on:
+  workflow_call:
+    inputs:
+      custom_title:
+        type: string
+        default: ""
+        description: >-
+          Custom title for the notification. If provided, 'type' and 'ref' are not required.
+          Supports Slack markdown formatting.
+      type:
+        type: string
+        default: ""
+        description: >-
+          The type of slack notification to send. Used to select one of two pre-defined
+          message templates. Required if 'custom_title' is not provided.
+
+          Accepted values:
+            - 'build'
+            - 'deployment'
+      ref:
+        type: string
+        default: ""
+        description: >-
+          The git ref (branch, tag, or SHA) that used during build or deployment.
+          Required if 'custom_title' is not provided.
+      status:
+        type: string
+        required: true
+        description: >-
+          The outcome of the build or deployment workflow.
+          Also controls the colored sidebar of the message.
+      service:
+        type: string
+        default: ""
+        description: >-
+          The target service or environment (e.g., 'saleor-v320-sandbox-eu',
+          'saleor-master-staging', etc). Only used when type is 'deployment'.
+
+    secrets:
+      slack-webhook-url:
+        required: true
+        description: >-
+          A Slack incoming webhook URL.
+          Our "Cloud Depoyments" slack app webhook URLs can be found here:
+          https://api.slack.com/apps/A0A56MD0DHS/incoming-webhooks?
+          They need to be declared in your repo as a workflow secrets.
+
+    outputs:
+      ok:
+        description: Whether the request completed without errors.
+        value: ${{ jobs.notify.outputs.ok }}
+      response:
+        description: A JSON stringified version of the Slack API response.
+        value: ${{ jobs.notify.outputs.response }}
+
+permissions: {}
+
+jobs:
+  notify:
+    name: Send Slack notification
+    runs-on: ubuntu-24.04
+
+    outputs:
+      ok: ${{ steps.notify-slack.outputs.ok }}
+      response: ${{ steps.notify-slack.outputs.response }}
+
+    steps:
+      - name: Generate Slack message payload
+        id: generate-payload
+        env:
+          TITLE_OVERRIDE: ${{ inputs.custom_title }}
+          TYPE: ${{ inputs.type }}
+          REF: ${{ inputs.ref }}
+          STATUS: ${{ inputs.status }}
+          SERVICE: ${{ inputs.service }}
+          REPO_NAME: ${{ github.event.repository.name }}
+          ACTOR: ${{ github.actor }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          WORKFLOW: ${{ github.workflow }}
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+        run: |
+          set -ux
+
+          # sidebar color based on status
+          case "$STATUS" in
+            success)   COLOR="#2EB67D" ;; # green
+            failure)   COLOR="#E01E5A" ;; # red
+            *)         COLOR="#868686" ;; # grey
+          esac
+
+          REPO_LINK="<${REPO_URL}|${REPO_NAME}>"
+
+          if [[ -n "$TITLE_OVERRIDE" ]]; then
+            TITLE="${REPO_LINK} | ${TITLE_OVERRIDE}"
+          else
+            # validate required inputs when not using custom title
+            if [[ -z "$TYPE" || -z "$REF" ]]; then
+              echo "::error::'type' and 'ref' are required when 'title' is not provided."
+              exit 1
+            fi
+
+            case "$TYPE" in
+              build|deployment) ;;
+              *)
+                echo "::error::Invalid type '$TYPE'. Must be one of: build, deployment."
+                exit 1
+                ;;
+            esac
+
+            TITLE="${REPO_LINK} | Finished ${TYPE} of *${REF}*"
+
+            if [[ "$TYPE" == "deployment" ]]; then
+              if [[ -z "$SERVICE" ]]; then
+                echo "::error::'service' is required when type is 'deployment'."
+                exit 1
+              fi
+              TITLE+=" to *${SERVICE}*"
+            fi
+          fi
+
+          # Extract workflow filename from github.workflow_ref (e.g., "owner/repo/.github/workflows/test.yml@refs/heads/main")
+          WORKFLOW_PATH="${WORKFLOW_REF%%@*}"  # owner/repo/.github/workflows/test.yml
+          WORKFLOW_FILE="${WORKFLOW_PATH##*/}" # test.yml
+          WORKFLOW_URL="${REPO_URL}/actions/workflows/${WORKFLOW_FILE}"
+
+          BODY="Author: *${ACTOR}*
+          Workflow: <${WORKFLOW_URL}|${WORKFLOW}>
+          Status: *${STATUS}*
+          <${RUN_URL}|View run logs>"
+
+          PAYLOAD=$(jq -cn \
+            --arg title "$TITLE" \
+            --arg body "$BODY" \
+            --arg color "$COLOR" \
+            '{ attachments: [{ color: $color, blocks: [
+              { type: "section", text: { type: "mrkdwn", text: $title } },
+              { type: "section", text: { type: "mrkdwn", text: $body } }
+            ]}] }')
+
+          echo "payload=$PAYLOAD" >> "$GITHUB_OUTPUT"
+
+      - name: Send Slack notification
+        id: notify-slack
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        with:
+          webhook: ${{ secrets.slack-webhook-url }}
+          webhook-type: incoming-webhook
+          payload: ${{ steps.generate-payload.outputs.payload }}
+          errors: true # We want the workflow to be marked as failed if the notification step fails - otherwise we will be likely to overlook notifications aren't working.

--- a/.github/workflows/notify-slack.yaml
+++ b/.github/workflows/notify-slack.yaml
@@ -32,12 +32,18 @@ on:
         description: >-
           The outcome of the build or deployment workflow.
           Also controls the colored sidebar of the message.
-      service:
+      product:
         type: string
         default: ""
         description: >-
-          The target service or environment (e.g., 'saleor-v320-sandbox-eu',
-          'saleor-master-staging', etc). Only used when type is 'deployment'.
+          The product being deployed (e.g., 'keycloak', 'saleor-multitenant',
+          'cloud-api', 'dashboard'). Required when type is 'deployment'.
+      environment:
+        type: string
+        default: ""
+        description: >-
+          The target environment (e.g., 'prod', 'staging', 'v322-staging').
+          Required when type is 'deployment'.
 
     secrets:
       slack-webhook-url:
@@ -75,7 +81,8 @@ jobs:
           TYPE: ${{ inputs.type }}
           REF: ${{ inputs.ref }}
           STATUS: ${{ inputs.status }}
-          SERVICE: ${{ inputs.service }}
+          PRODUCT: ${{ inputs.product }}
+          ENVIRONMENT: ${{ inputs.environment }}
           REPO_NAME: ${{ github.event.repository.name }}
           ACTOR: ${{ github.actor }}
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
@@ -104,22 +111,21 @@ jobs:
             fi
 
             case "$TYPE" in
-              build|deployment) ;;
+              build)
+                TITLE="${REPO_LINK} | Finished build of *${REF}*"
+                ;;
+              deployment)
+                if [[ -z "$PRODUCT" || -z "$ENVIRONMENT" ]]; then
+                  echo "::error::'product' and 'environment' are required when type is 'deployment'."
+                  exit 1
+                fi
+                TITLE="${REPO_LINK} | *${PRODUCT}* | Finished deployment of *${REF}* to *${ENVIRONMENT}*"
+                ;;
               *)
                 echo "::error::Invalid type '$TYPE'. Must be one of: build, deployment."
                 exit 1
                 ;;
             esac
-
-            TITLE="${REPO_LINK} | Finished ${TYPE} of *${REF}*"
-
-            if [[ "$TYPE" == "deployment" ]]; then
-              if [[ -z "$SERVICE" ]]; then
-                echo "::error::'service' is required when type is 'deployment'."
-                exit 1
-              fi
-              TITLE+=" to *${SERVICE}*"
-            fi
           fi
 
           # Extract workflow filename from github.workflow_ref (e.g., "owner/repo/.github/workflows/test.yml@refs/heads/main")

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This is a collection of GitHub Actions created and used by Saleor internally.
 | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [run-license-check.yaml](.github/workflows/run-license-check.yaml)                             | Summarizes the list of licenses as a pull request comment (by generating an SBOM.)                                                                                        |
 | [build-push-image-multi-platform.yaml](.github/workflows/build-push-image-multi-platform.yaml) | Blazing fast building for multi-arch OCI images (ARM64 and AMD64 only). See [documentation](/.github/workflows/build-push-image-multi-platform.md) for usage information. |
+| [notify-slack.yaml](.github/workflows/notify-slack.yaml)                                       | Sends templated Slack notifications via incoming webhooks. See [documentation](/.github/workflows/notify-slack.md) for usage information.                                 |
 
 ## Development
 


### PR DESCRIPTION
## Summary

Adds a reusable GitHub workflow for sending Slack notifications via incoming webhooks. Provides a consistent interface for build and deployment notifications across Saleor workflows, as well as allows for sending messages with the custom title.

Every message will contain the same body:
```
Author: username

Workflow: [workflow-name](link-to-workflow-runs-view)

Status: status

[View run logs](link-to-specific-workflow-run0-logs)
```

## Features

- **Colored sidebar** based on status: green (success), red (failure), grey (other)
- **Two notification types**: `build` and `deployment`
- **Custom title support** for non-standard notifications
- **Automatic repo link** prepended to all titles
- **Workflow link** in body pointing to the caller's workflow
- **Logs link** in body pointing to the logs of specific run

## Usage

### Build notification
```yaml
uses: saleor/saleor-internal-actions/.github/workflows/notify-slack.yaml@main
with:
  type: build
  ref: ${{ github.ref_name }}
  status: ${{ needs.build.result }}
secrets:
  slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
```

### Deployment notification
```yaml
uses: saleor/saleor-internal-actions/.github/workflows/notify-slack.yaml@main
with:
  type: deployment
  ref: ${{ github.ref_name }}
  product: multitenant
  environment: saleor-v322-sandbox-us
  status: ${{ needs.deploy.result }}
secrets:
  slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
```

### Custom title
```yaml
uses: saleor/saleor-internal-actions/.github/workflows/notify-slack.yaml@main
with:
  custom_title: "*Custom task* completed"
  status: ${{ needs.task.result }}
secrets:
  slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
```

## Required inputs

| Scenario | Required inputs |
|----------|-----------------|
| Build | `type`, `ref`, `status` |
| Deployment | `type`, `ref`, `product`, `environment`, `status` |
| Custom | `custom_title`, `status` |
