### PR TITLE
feat(notify-slack): Improve mention_id handling, allow conditional mentions and allow for custom body

### DIFF
--- a/.github/workflows/notify-slack.md
+++ b/.github/workflows/notify-slack.md
@@ -49,7 +49,14 @@ workflow run. Optionally, a Slack user group can be mentioned in the message.
     >
     > [View run logs]()
 
-4. When `mention_group_id` is provided:
+4. When `custom_body:` is provided (with any title option):
+    > [repo-name]() | {title}
+    >
+    > {your custom body}
+    >
+    > [View run logs]()
+
+5. When `mention_group_id` is provided:
     > [repo-name]() | Finished build of **{ref}**
     >
     > Author: **username**
@@ -69,6 +76,7 @@ workflow run. Optionally, a Slack user group can be mentioned in the message.
 | Input name | Description                                                                  | Type   | Default | Notes                                            |
 | ---------- | ---------------------------------------------------------------------------- | ------ | ------- | ------------------------------------------------ |
 | `custom_title` | Custom title for the notification. Supports Slack mrkdwn.                | string | `""`    | If provided, `type` and `ref` are not required.  |
+| `custom_body` | Custom body for the notification. Supports Slack mrkdwn.                  | string | `""`    | Replaces default body. Mention + run logs link still appended. |
 | `type`     | The type of notification: `build` or `deployment`.                           | string | `""`    | Required if `custom_title` is not provided.             |
 | `ref`      | The git ref (branch, tag, or SHA) that was built or deployed.                | string | `""`    | Required if `custom_title` is not provided.             |
 | `status`   | The outcome of the workflow. Controls sidebar color (green=success, red=failure, grey=other). | string | -       | **Required**.                                    |
@@ -173,6 +181,31 @@ jobs:
     uses: saleor/saleor-internal-actions/.github/workflows/notify-slack.yaml@main
     with:
       custom_title: "*Custom task* completed"
+      status: ${{ needs.task.result }}
+    secrets:
+      slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+```
+
+### Custom body notification
+
+```yaml
+name: Custom Body Notification
+on:
+  workflow_dispatch:
+
+jobs:
+  task:
+    runs-on: ubuntu-24.04
+    steps:
+      - run: echo "Doing something..."
+
+  notify:
+    needs: task
+    if: ${{ always() }}
+    uses: saleor/saleor-internal-actions/.github/workflows/notify-slack.yaml@main
+    with:
+      custom_title: "Database migration"
+      custom_body: "Migrated *users* table\nAffected rows: *1,234*"
       status: ${{ needs.task.result }}
     secrets:
       slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/notify-slack.md
+++ b/.github/workflows/notify-slack.md
@@ -75,6 +75,7 @@ workflow run. Optionally, a Slack user group can be mentioned in the message.
 | `product`  | The product being deployed (e.g., `keycloak`, `saleor-multitenant`).         | string | `""`    | Required when `type` is `deployment`.            |
 | `environment` | The target environment (e.g., `prod`, `staging`, `v322-staging`).         | string | `""`    | Required when `type` is `deployment`.            |
 | `mention_group_id` | Slack user group ID to mention.                                         | string | `""`    | If provided, the group will be @mentioned.       |
+| `mention_on` | Comma-separated statuses that trigger the @mention. Custom values also accepted. | string | `"always"` | e.g., `failure` or `failure,cancelled`. |
 
 ### Secrets
 
@@ -177,7 +178,7 @@ jobs:
       slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 ```
 
-### Notification with group mention
+### Notification with group mention (on failure only)
 
 ```yaml
 name: Build with team notification
@@ -201,11 +202,12 @@ jobs:
       ref: ${{ github.ref_name }}
       status: ${{ needs.build.result }}
       mention_group_id: S0123456789
+      mention_on: failure
     secrets:
       slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 ```
 
-### Notification with group mention (as secret)
+### Notification with group mention (secret, multiple statuses)
 
 If your repo stores the group ID as a secret instead of a variable:
 
@@ -230,6 +232,7 @@ jobs:
       type: build
       ref: ${{ github.ref_name }}
       status: ${{ needs.build.result }}
+      mention_on: failure,cancelled
     secrets:
       slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
       mention_group_id: ${{ secrets.SLACK_MENTION_GROUP_ID }}

--- a/.github/workflows/notify-slack.md
+++ b/.github/workflows/notify-slack.md
@@ -81,6 +81,7 @@ workflow run. Optionally, a Slack user group can be mentioned in the message.
 | Secret name         | Description                     | Notes                                                                                                   |
 | ------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------- |
 | `slack-webhook-url` | A Slack incoming webhook URL.   | **Required**. Our "Cloud Deployments" app webhooks can be found [here][cloud-deployments-app-webhooks]. |
+| `mention_group_id`  | Slack user group ID to mention. | Use this instead of the input when the group ID is stored as a repo secret. Secret takes precedence over input. |
 
 ### Outputs
 
@@ -199,9 +200,39 @@ jobs:
       type: build
       ref: ${{ github.ref_name }}
       status: ${{ needs.build.result }}
-      mention_group_id: ${{ needs.build.result == 'failure' && 'S0123456789' || '' }}
+      mention_group_id: S0123456789
     secrets:
       slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+```
+
+### Notification with group mention (as secret)
+
+If your repo stores the group ID as a secret instead of a variable:
+
+```yaml
+name: Build with team notification
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - run: make build
+
+  notify:
+    needs: build
+    if: ${{ always() }}
+    uses: saleor/saleor-internal-actions/.github/workflows/notify-slack.yaml@main
+    with:
+      type: build
+      ref: ${{ github.ref_name }}
+      status: ${{ needs.build.result }}
+    secrets:
+      slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+      mention_group_id: ${{ secrets.SLACK_MENTION_GROUP_ID }}
 ```
 
 > **Tip:** To find a Slack user group ID, right-click on a group mention in Slack

--- a/.github/workflows/notify-slack.yaml
+++ b/.github/workflows/notify-slack.yaml
@@ -60,6 +60,12 @@ on:
           Our "Cloud Deployments" slack app webhook URLs can be found here:
           https://api.slack.com/apps/A0A56MD0DHS/incoming-webhooks?
           They need to be declared in your repo as a workflow secrets.
+      mention_group_id:
+        required: false
+        description: >-
+          Slack user group ID to mention (e.g., 'S0123456789').
+          Use this instead of the input when the group ID is stored as a repo secret.
+          If both the secret and input are provided, the secret takes precedence.
 
     outputs:
       ok:
@@ -90,7 +96,7 @@ jobs:
           STATUS: ${{ inputs.status }}
           PRODUCT: ${{ inputs.product }}
           ENVIRONMENT: ${{ inputs.environment }}
-          MENTION_GROUP_ID: ${{ inputs.mention_group_id }}
+          MENTION_GROUP_ID: ${{ secrets.mention_group_id || inputs.mention_group_id }}
           REPO_NAME: ${{ github.event.repository.name }}
           ACTOR: ${{ github.actor }}
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}

--- a/.github/workflows/notify-slack.yaml
+++ b/.github/workflows/notify-slack.yaml
@@ -10,6 +10,13 @@ on:
         description: >-
           Custom title for the notification. If provided, 'type' and 'ref' are not required.
           Supports Slack markdown formatting.
+      custom_body:
+        type: string
+        default: ""
+        description: >-
+          Custom body for the notification. If provided, replaces the default body
+          (Author, Workflow, Status). The @mention and "View run logs" link are still
+          appended automatically. Supports Slack markdown formatting.
       type:
         type: string
         default: ""
@@ -58,7 +65,7 @@ on:
           Comma-separated list of statuses that trigger the @mention (e.g., 'failure',
           'failure,cancelled'). Set to 'always' to mention on every status.
           Only relevant when 'mention_group_id' is provided.
-          Typical statuses are: 'success', 'failure', 'cancelled', 'skipped' - but
+          Typical statuses are: 'success', 'failure', 'cancelled', 'skipped' - but 
           custom values are also accepted.
 
     secrets:
@@ -100,6 +107,7 @@ jobs:
         id: generate-payload
         env:
           TITLE_OVERRIDE: ${{ inputs.custom_title }}
+          BODY_OVERRIDE: ${{ inputs.custom_body }}
           TYPE: ${{ inputs.type }}
           REF: ${{ inputs.ref }}
           STATUS: ${{ inputs.status }}
@@ -186,9 +194,13 @@ jobs:
             fi
           fi
 
-          BODY="Author: *${ACTOR}*
+          if [[ -n "$BODY_OVERRIDE" ]]; then
+            BODY="$BODY_OVERRIDE"
+          else
+            BODY="Author: *${ACTOR}*
           Workflow: <${WORKFLOW_URL}|${WORKFLOW}>
           Status: *${STATUS}*"
+          fi
           if [[ "$SHOULD_MENTION" == true ]]; then
             BODY+=$'\n'"<!subteam^${MENTION_GROUP_ID}>"
           fi

--- a/.github/workflows/notify-slack.yaml
+++ b/.github/workflows/notify-slack.yaml
@@ -51,6 +51,15 @@ on:
           Slack user group ID to mention (e.g., 'S0123456789').
           If provided, the group will be mentioned in the notification.
           Find group IDs in Slack by right-clicking a group mention and copying the link.
+      mention_on:
+        type: string
+        default: "always"
+        description: >-
+          Comma-separated list of statuses that trigger the @mention (e.g., 'failure',
+          'failure,cancelled'). Set to 'always' to mention on every status.
+          Only relevant when 'mention_group_id' is provided.
+          Typical statuses are: 'success', 'failure', 'cancelled', 'skipped' - but
+          custom values are also accepted.
 
     secrets:
       slack-webhook-url:
@@ -97,6 +106,7 @@ jobs:
           PRODUCT: ${{ inputs.product }}
           ENVIRONMENT: ${{ inputs.environment }}
           MENTION_GROUP_ID: ${{ secrets.mention_group_id || inputs.mention_group_id }}
+          MENTION_ON: ${{ inputs.mention_on }}
           REPO_NAME: ${{ github.event.repository.name }}
           ACTOR: ${{ github.actor }}
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
@@ -106,19 +116,26 @@ jobs:
         run: |
           set -ux
 
-          # sidebar color based on status
+          # select sidebar color
           case "$STATUS" in
             success)   COLOR="#2EB67D" ;; # green
             failure)   COLOR="#E01E5A" ;; # red
             *)         COLOR="#868686" ;; # grey
           esac
 
+          # used in every title
           REPO_LINK="<${REPO_URL}|${REPO_NAME}>"
 
+          # used in every body
+          WORKFLOW_PATH="${WORKFLOW_REF%%@*}"  # owner/repo/.github/workflows/test.yml
+          WORKFLOW_FILE="${WORKFLOW_PATH##*/}" # test.yml
+          WORKFLOW_URL="${REPO_URL}/actions/workflows/${WORKFLOW_FILE}"
+
+          # use custom title (if provided) - otherwise select one of two predefined
+          # title templates. Includes input validation.
           if [[ -n "$TITLE_OVERRIDE" ]]; then
             TITLE="${REPO_LINK} | ${TITLE_OVERRIDE}"
           else
-            # validate required inputs when not using custom title
             if [[ -z "$TYPE" || -z "$REF" ]]; then
               echo "::error::'type' and 'ref' are required when 'title' is not provided."
               exit 1
@@ -142,20 +159,39 @@ jobs:
             esac
           fi
 
-          # Extract workflow filename from github.workflow_ref (e.g., "owner/repo/.github/workflows/test.yml@refs/heads/main")
-          WORKFLOW_PATH="${WORKFLOW_REF%%@*}"  # owner/repo/.github/workflows/test.yml
-          WORKFLOW_FILE="${WORKFLOW_PATH##*/}" # test.yml
-          WORKFLOW_URL="${REPO_URL}/actions/workflows/${WORKFLOW_FILE}"
+          # Decide if @mention should be included (depending on the workflow result)
+          SHOULD_MENTION=false
+          if [[ -n "$MENTION_GROUP_ID" ]]; then
+            if [[ ! "$MENTION_GROUP_ID" =~ ^S[A-Z0-9]+$ ]]; then
+              echo "::error::Invalid mention_group_id '$MENTION_GROUP_ID'. Expected a Slack group ID (e.g., 'S0123456789')."
+              exit 1
+            fi
+            if [[ ! "$MENTION_ON" =~ ^[a-zA-Z,\ ]+$ ]]; then
+              echo "::error::Invalid mention_on value '$MENTION_ON'. Only letters, commas, and spaces are allowed."
+              exit 1
+            fi
+
+            if [[ "$MENTION_ON" == "always" ]]; then
+              SHOULD_MENTION=true
+            else
+              # Split "failure,cancelled" into an array on commas, then strip
+              # spaces from each entry and finally compare against current STATUS.
+              IFS=',' read -ra MENTION_STATUSES <<< "$MENTION_ON"
+              for s in "${MENTION_STATUSES[@]}"; do
+                if [[ "${s// /}" == "$STATUS" ]]; then
+                  SHOULD_MENTION=true
+                  break
+                fi
+              done
+            fi
+          fi
 
           BODY="Author: *${ACTOR}*
           Workflow: <${WORKFLOW_URL}|${WORKFLOW}>
           Status: *${STATUS}*"
-
-          # Add group mention if configured
-          if [[ -n "$MENTION_GROUP_ID" ]]; then
+          if [[ "$SHOULD_MENTION" == true ]]; then
             BODY+=$'\n'"<!subteam^${MENTION_GROUP_ID}>"
           fi
-
           BODY+=$'\n'"<${RUN_URL}|View run logs>"
 
           PAYLOAD=$(jq -cn \


### PR DESCRIPTION
this PR introduces 3 improvements - for easier review, the changes are atomic - one improvement per commit

Prompted by the fact I didn't realize some repos treat slack group ID as secret, and thus some of our workflows are incompatible.