### PR TITLE
feat(build-push): add support for GitHub Environments

### DIFF
--- a/.github/workflows/build-push-image-multi-platform.md
+++ b/.github/workflows/build-push-image-multi-platform.md
@@ -75,6 +75,8 @@ Secrets (**only** required when passing `checkout-use-vault: true`):
 | `build-args`           | List of `--build-arg` arguments to pass to the builder.                                                                                                                                                                                                       | string  | -                    | See example below.                                                                                                                             |
 | `publish-environment`  | The [GitHub Environment] to use to build & push the image. This prevents unauthorized access to secrets by adding an additional protection layer. This also allows to add the `environment` claim to OIDC token which can then be checked by AWS for example. | string  | No environment used. | IMPORTANT: you must pass `secrets: inherit` if you use the `publish-environment` input.[^1] [^2] See our example: [Using GitHub Environments]. |
 
+[GitHub Environment]: https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments
+
 [^1]: https://github.com/actions/runner/issues/3206
 
 [^2]: https://github.com/actions/runner/issues/1490

--- a/.github/workflows/build-push-image-multi-platform.md
+++ b/.github/workflows/build-push-image-multi-platform.md
@@ -64,15 +64,20 @@ Secrets (**only** required when passing `checkout-use-vault: true`):
 
 **Build Settings**:
 
-| Input name             | Description                                                                                                                    | Type    | Default        | Notes                                                                                                                |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------- | -------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `context-path`         | The path to use as the build context.                                                                                          | string  | `./`           |                                                                                                                      |
-| `dockerfile-path`      | The path to the Dockerfile to build.                                                                                           | string  | `./Dockerfile` |                                                                                                                      |
-| `target`               | The build stage to use in the Dockerfile (same as `docker build --target <TARGET>`)                                            | string  | -              |                                                                                                                      |
-| `docker-build-summary` | Whether to generate a build summary (https://docs.docker.com/build/ci/github-actions/build-summary/)                           | boolean | `true`         |                                                                                                                      |
-| `oci-full-repository`  | Fully‑qualified OCI registry URI (including registry host, namespace and image name), e.g., `oci.example.com/acme/my-project`. | string  | –              | **Required** – the _target_ registry where the image will be pushed. Can be passed in the `with` or `secrets` block. |
-| `tags`                 | Comma or newline-separated list of tags to apply to the final image (e.g. `latest,v1,v1.0.1`).                                 | string  | –              | **Required**.                                                                                                        |
-| `build-args`           | List of `--build-arg` arguments to pass to the builder.                                                                        | string  | -              | See example below.                                                                                                   |
+| Input name             | Description                                                                                                                                                                                                                                                   | Type    | Default              | Notes                                                                                                                                          |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `context-path`         | The path to use as the build context.                                                                                                                                                                                                                         | string  | `./`                 |                                                                                                                                                |
+| `dockerfile-path`      | The path to the Dockerfile to build.                                                                                                                                                                                                                          | string  | `./Dockerfile`       |                                                                                                                                                |
+| `target`               | The build stage to use in the Dockerfile (same as `docker build --target <TARGET>`)                                                                                                                                                                           | string  | -                    |                                                                                                                                                |
+| `docker-build-summary` | Whether to generate a build summary (https://docs.docker.com/build/ci/github-actions/build-summary/)                                                                                                                                                          | boolean | `true`               |                                                                                                                                                |
+| `oci-full-repository`  | Fully‑qualified OCI registry URI (including registry host, namespace and image name), e.g., `oci.example.com/acme/my-project`.                                                                                                                                | string  | –                    | **Required** – the _target_ registry where the image will be pushed. Can be passed in the `with` or `secrets` block.                           |
+| `tags`                 | Comma or newline-separated list of tags to apply to the final image (e.g. `latest,v1,v1.0.1`).                                                                                                                                                                | string  | –                    | **Required**.                                                                                                                                  |
+| `build-args`           | List of `--build-arg` arguments to pass to the builder.                                                                                                                                                                                                       | string  | -                    | See example below.                                                                                                                             |
+| `publish-environment`  | The [GitHub Environment] to use to build & push the image. This prevents unauthorized access to secrets by adding an additional protection layer. This also allows to add the `environment` claim to OIDC token which can then be checked by AWS for example. | string  | No environment used. | IMPORTANT: you must pass `secrets: inherit` if you use the `publish-environment` input.[^1] [^2] See our example: [Using GitHub Environments]. |
+
+[^1]: https://github.com/actions/runner/issues/3206
+
+[^2]: https://github.com/actions/runner/issues/1490
 
 Secrets:
 
@@ -275,6 +280,51 @@ For more information, refer to the following resources:
 - https://docs.docker.com/build/building/secrets/
 
 [securely]: https://docs.docker.com/reference/build-checks/secrets-used-in-arg-or-env/
+[Using GitHub Environments]: #using-github-environments
+
+### Using GitHub Environments
+
+Using environments you can restrict which branches or tags can access the secrets,
+and you can add additional deployment gates (such as requiring specific persons
+to approve the workflow's run).
+
+**Important:**
+
+- Due to a [GitHub limitation with reusable workflows secrets], secrets are
+  not available unless you inherit secrets from the caller workflow (`secrets: inherit`).
+- Our workflows expect secret names in lowercase with dashes
+  (e.g. `aws-ecr-role-to-assume`). However, GitHub environment secrets only support
+  `[A-Z_]+`, thus all secrets must be renamed when added to the environment:
+
+  `aws-ecr-role-to-assume` -> `AWS_ECR_ROLE_TO_ASSUME`
+
+  This applies and works with any secret used by our workflow.
+
+Example:
+
+```yaml
+on:
+  push: [main]
+
+jobs:
+  build-image:
+    uses: saleor/saleor-build-workflow/.github/workflows/build.yaml@main
+    with:
+      oci-full-repository: "123456789012.dkr.ecr.us-east-1.amazonaws.com/saleor/saleor"
+      enable-aws-ecr: true
+      publish-environment: my-publish-to-ecr-environment # <-- the GitHub environment name
+    secrets: inherit # <-- Important! Secrets will not work otherwise.
+```
+
+Setting a secret:
+
+<img
+  alt="Screenshot of GitHub Environment page showing protection rules and AWS_ECR_ROLE_TO_ASSUME secret"
+  width=550
+  src="https://github.com/user-attachments/assets/60f47e42-4329-46c9-bd40-d6864ef0de12"
+/>
+
+[GitHub limitation with reusable workflows secrets]: https://github.com/actions/runner/issues/1490
 
 ## Architecture
 

--- a/.github/workflows/build-push-image-multi-platform.yaml
+++ b/.github/workflows/build-push-image-multi-platform.yaml
@@ -128,6 +128,12 @@ on:
         type: string
         description: >-
           The AWS region where to push.
+      publish-environment:
+        type: string
+        description: >-
+          The GitHub environment to use for building & pushing the image.
+          This is used for checking the `environment` OIDC claim, and
+          separating sensitive secrets.
 
     secrets:
       checkout-vault-url:
@@ -179,6 +185,7 @@ jobs:
   build:
     name: Build (${{ matrix.runner-image }})
     runs-on: ${{ matrix.runner-image }}
+    environment: ${{ inputs.publish-environment }}
 
     strategy:
       matrix:
@@ -195,7 +202,7 @@ jobs:
       - name: Validate Inputs
         env:
           INPUT_OCI_REPO: ${{ inputs.oci-full-repository }}
-          SECRET_OCI_REPO: ${{ secrets.oci-full-repository }}
+          SECRET_OCI_REPO: ${{ secrets.oci-full-repository || secrets.OCI_FULL_REPOSITORY }}
         run: |
           set -u -o pipefail
 
@@ -212,8 +219,8 @@ jobs:
         name: Get Checkout Token
         if: ${{ inputs.checkout-use-vault }}
         env:
-          VAULT_URL: ${{ secrets.checkout-vault-url }}
-          VAULT_JWT: ${{ secrets.checkout-vault-jwt }}
+          VAULT_URL: ${{ secrets.checkout-vault-url || secrets.CHECKOUT_VAULT_URL }}
+          VAULT_JWT: ${{ secrets.checkout-vault-jwt || secrets.CHECKOUT_VAULT_URL }}
         run: |
           token=$(
             curl --request GET --url "$VAULT_URL" --header "Authorization: JWT $VAULT_JWT" | jq -r .token
@@ -238,14 +245,14 @@ jobs:
         name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
-          role-to-assume: ${{ secrets.aws-ecr-role-to-assume }}
+          role-to-assume: ${{ secrets.aws-ecr-role-to-assume || secrets.AWS_ECR_ROLE_TO_ASSUME }}
           aws-region: ${{ inputs.aws-ecr-region }}
 
       - if: ${{ inputs.enable-aws-ecr }}
         name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
         with:
-          registries: ${{ secrets.aws-ecr-registries }}
+          registries: ${{ secrets.aws-ecr-registries || secrets.AWS_ECR_REGISTRIES }}
 
       - if: ${{ inputs.enable-ghcr }}
         name: Login to GitHub Container Registry
@@ -270,11 +277,11 @@ jobs:
           # We set `push-by-digest=true` thus we cannot put any tag and thus we use
           # the container repository name instead (ghcr.io/saleor/saleor)
           # (we cannot push both by tags and by digest, only one or the other)
-          tags: ${{ inputs.oci-full-repository || secrets.oci-full-repository }}
+          tags: ${{ inputs.oci-full-repository || secrets.oci-full-repository || secrets.OCI_FULL_REPOSITORY }}
           labels: ${{ inputs.labels }}
           build-args: ${{ inputs.build-args }}
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true,oci-mediatypes=true
-          secrets: ${{ secrets.build-secrets }}
+          secrets: ${{ secrets.build-secrets || secrets.BUILD_SECRETS }}
 
       - name: Export digest
         env:
@@ -297,6 +304,7 @@ jobs:
     needs: build
 
     runs-on: ubuntu-24.04
+    environment: ${{ inputs.publish-environment }}
 
     permissions:
       id-token: write # Needed for AWS login
@@ -316,14 +324,14 @@ jobs:
         name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
         with:
-          role-to-assume: ${{ secrets.aws-ecr-role-to-assume }}
+          role-to-assume: ${{ secrets.aws-ecr-role-to-assume || secrets.AWS_ECR_ROLE_TO_ASSUME }}
           aws-region: ${{ inputs.aws-ecr-region }}
 
       - if: ${{ inputs.enable-aws-ecr }}
         name: Login to Amazon ECR
         uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
         with:
-          registries: ${{ secrets.aws-ecr-registries }}
+          registries: ${{ secrets.aws-ecr-registries || secrets.AWS_ECR_REGISTRIES }}
 
       - name: Download digests
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
@@ -344,7 +352,7 @@ jobs:
         id: push-manifest
         working-directory: ${{ runner.temp }}/digests
         env:
-          REPO: ${{ inputs.oci-full-repository || secrets.oci-full-repository }}
+          REPO: ${{ inputs.oci-full-repository || secrets.oci-full-repository || secrets.OCI_FULL_REPOSITORY }}
           IMAGE_TAGS: ${{ inputs.tags }}
         run: |
           set -u -o pipefail

--- a/.github/workflows/notify-slack.md
+++ b/.github/workflows/notify-slack.md
@@ -17,61 +17,57 @@ workflow run. Optionally, a Slack user group can be mentioned in the message.
 ### Message format - depends on the inputs:
 
 1. When `type: build` is provided:
-
-   > [repo-name]() | Finished build of **{ref}**
-   >
-   > Author: **username**
-   >
-   > Workflow: [workflow-name]()
-   >
-   > Status: **status**
-   >
-   > [View run logs]()
+    > [repo-name]() | Finished build of **{ref}**
+    >
+    > Author: **username**
+    >
+    > Workflow: [workflow-name]()
+    >
+    > Status: **status**
+    >
+    > [View run logs]()
 
 2. When `type: deployment` is provided:
-
-   > [repo-name]() | **{product}** | Finished deployment of **{ref}** to **{cloud-environment-name}**
-   >
-   > Author: **username**
-   >
-   > Workflow: [workflow-name]()
-   >
-   > Status: **status**
-   >
-   > [View run logs]()
+    > [repo-name]() | **{product}** | Finished deployment of **{ref}** to **{cloud-environment-name}**
+    >
+    > Author: **username**
+    >
+    > Workflow: [workflow-name]()
+    >
+    > Status: **status**
+    >
+    > [View run logs]()
 
 3. When `custom_title:` is provided:
-
-   > [repo-name]() | {your custom title}
-   >
-   > Author: **username**
-   >
-   > Workflow: [workflow-name]()
-   >
-   > Status: **status**
-   >
-   > [View run logs]()
+    > [repo-name]() | {your custom title}
+    >
+    > Author: **username**
+    >
+    > Workflow: [workflow-name]()
+    >
+    > Status: **status**
+    >
+    > [View run logs]()
 
 4. When `custom_body:` is provided (with any title option):
-
-   > [repo-name]() | {title}
-   >
-   > {your custom body}
-   >
-   > [View run logs]()
+    > [repo-name]() | {title}
+    >
+    > {your custom body}
+    >
+    > [View run logs]()
 
 5. When `mention_group_id` is provided:
-   > [repo-name]() | Finished build of **{ref}**
-   >
-   > Author: **username**
-   >
-   > Workflow: [workflow-name]()
-   >
-   > Status: **status**
-   >
-   > @team-name
-   >
-   > [View run logs]()
+    > [repo-name]() | Finished build of **{ref}**
+    >
+    > Author: **username**
+    >
+    > Workflow: [workflow-name]()
+    >
+    > Status: **status**
+    >
+    > @team-name
+    >
+    > [View run logs]()
 
 ## Usage
 

--- a/.github/workflows/notify-slack.md
+++ b/.github/workflows/notify-slack.md
@@ -17,79 +17,90 @@ workflow run. Optionally, a Slack user group can be mentioned in the message.
 ### Message format - depends on the inputs:
 
 1. When `type: build` is provided:
-    > [repo-name]() | Finished build of **{ref}**
-    >
-    > Author: **username**
-    >
-    > Workflow: [workflow-name]()
-    >
-    > Status: **status**
-    >
-    > [View run logs]()
+
+   > [repo-name]() | Finished build of **{ref}**
+   >
+   > Author: **username**
+   >
+   > Workflow: [workflow-name]()
+   >
+   > Status: **status**
+   >
+   > [View run logs]()
 
 2. When `type: deployment` is provided:
-    > [repo-name]() | **{product}** | Finished deployment of **{ref}** to **{environment}**
-    >
-    > Author: **username**
-    >
-    > Workflow: [workflow-name]()
-    >
-    > Status: **status**
-    >
-    > [View run logs]()
+
+   > [repo-name]() | **{product}** | Finished deployment of **{ref}** to **{cloud-environment-name}**
+   >
+   > Author: **username**
+   >
+   > Workflow: [workflow-name]()
+   >
+   > Status: **status**
+   >
+   > [View run logs]()
 
 3. When `custom_title:` is provided:
-    > [repo-name]() | {your custom title}
-    >
-    > Author: **username**
-    >
-    > Workflow: [workflow-name]()
-    >
-    > Status: **status**
-    >
-    > [View run logs]()
+
+   > [repo-name]() | {your custom title}
+   >
+   > Author: **username**
+   >
+   > Workflow: [workflow-name]()
+   >
+   > Status: **status**
+   >
+   > [View run logs]()
 
 4. When `custom_body:` is provided (with any title option):
-    > [repo-name]() | {title}
-    >
-    > {your custom body}
-    >
-    > [View run logs]()
+
+   > [repo-name]() | {title}
+   >
+   > {your custom body}
+   >
+   > [View run logs]()
 
 5. When `mention_group_id` is provided:
-    > [repo-name]() | Finished build of **{ref}**
-    >
-    > Author: **username**
-    >
-    > Workflow: [workflow-name]()
-    >
-    > Status: **status**
-    >
-    > @team-name
-    >
-    > [View run logs]()
+   > [repo-name]() | Finished build of **{ref}**
+   >
+   > Author: **username**
+   >
+   > Workflow: [workflow-name]()
+   >
+   > Status: **status**
+   >
+   > @team-name
+   >
+   > [View run logs]()
 
 ## Usage
 
 ### Inputs
 
-| Input name | Description                                                                  | Type   | Default | Notes                                            |
-| ---------- | ---------------------------------------------------------------------------- | ------ | ------- | ------------------------------------------------ |
-| `custom_title` | Custom title for the notification. Supports Slack mrkdwn.                | string | `""`    | If provided, `type` and `ref` are not required.  |
-| `custom_body` | Custom body for the notification. Supports Slack mrkdwn.                  | string | `""`    | Replaces default body. Mention + run logs link still appended. |
-| `type`     | The type of notification: `build` or `deployment`.                           | string | `""`    | Required if `custom_title` is not provided.             |
-| `ref`      | The git ref (branch, tag, or SHA) that was built or deployed.                | string | `""`    | Required if `custom_title` is not provided.             |
-| `status`   | The outcome of the workflow. Controls sidebar color (green=success, red=failure, grey=other). | string | -       | **Required**.                                    |
-| `product`  | The product being deployed (e.g., `keycloak`, `saleor-multitenant`).         | string | `""`    | Required when `type` is `deployment`.            |
-| `environment` | The target environment (e.g., `prod`, `staging`, `v322-staging`).         | string | `""`    | Required when `type` is `deployment`.            |
-| `mention_group_id` | Slack user group ID to mention.                                         | string | `""`    | If provided, the group will be @mentioned.       |
-| `mention_on` | Comma-separated statuses that trigger the @mention. Custom values also accepted. | string | `"always"` | e.g., `failure` or `failure,cancelled`. |
+| Input name               | Description                                                                                                                                       | Type   | Default              | Notes                                                                                                                        |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------ | -------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `github-environment`     | The [GitHub Environment] to use to build & push the image. This prevents unauthorized access to secrets by adding an additional protection layer. | string | No environment used. | `secrets: inherit` must be provided due to limitations with GitHub [^1]. Refer to [Using GitHub Environments] for more info. |
+| `custom_title`           | Custom title for the notification. Supports Slack markdown.                                                                                       | string | `""`                 | If provided, `type` and `ref` are not required.                                                                              |
+| `custom_body`            | Custom body for the notification. Supports Slack markdown.                                                                                        | string | `""`                 | Replaces default body. Mention + run logs link still appended.                                                               |
+| `type`                   | The type of notification: `build` or `deployment`.                                                                                                | string | `""`                 | Required if `custom_title` is not provided.                                                                                  |
+| `ref`                    | The git ref (branch, tag, or SHA) that was built or deployed.                                                                                     | string | `""`                 | Required if `custom_title` is not provided.                                                                                  |
+| `status`                 | The outcome of the workflow. Controls sidebar color (green=success, red=failure, grey=other).                                                     | string | -                    | **Required**.                                                                                                                |
+| `product`                | The product being deployed (e.g., `keycloak`, `saleor-multitenant`).                                                                              | string | `""`                 | Required when `type` is `deployment`.                                                                                        |
+| `cloud-environment-name` | The target environment (e.g., `prod`, `staging`, `v322-staging`).                                                                                 | string | `""`                 | Required when `type` is `deployment`.                                                                                        |
+| `mention_group_id`       | Slack user group ID to mention.                                                                                                                   | string | `""`                 | If provided, the group will be @mentioned.                                                                                   |
+| `mention_on`             | Comma-separated statuses that trigger the @mention. Custom values also accepted.                                                                  | string | `"always"`           | e.g., `failure` or `failure,cancelled`.                                                                                      |
+
+[GitHub Environment]: https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments
+
+[^1]: https://github.com/actions/runner/issues/1490
+
+[Secrets]: #secrets
 
 ### Secrets
 
-| Secret name         | Description                     | Notes                                                                                                   |
-| ------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| `slack-webhook-url` | A Slack incoming webhook URL.   | **Required**. Our "Cloud Deployments" app webhooks can be found [here][cloud-deployments-app-webhooks]. |
+| Secret name         | Description                     | Notes                                                                                                           |
+| ------------------- | ------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `slack-webhook-url` | A Slack incoming webhook URL.   | **Required**. Our "Cloud Deployments" app webhooks can be found [here][cloud-deployments-app-webhooks].         |
 | `mention_group_id`  | Slack user group ID to mention. | Use this instead of the input when the group ID is stored as a repo secret. Secret takes precedence over input. |
 
 ### Outputs
@@ -98,6 +109,28 @@ workflow run. Optionally, a Slack user group can be mentioned in the message.
 | ----------- | ----------------------------------------------------- |
 | `ok`        | Whether the request completed without errors.         |
 | `response`  | A JSON stringified version of the Slack API response. |
+
+[Using GitHub Environments]: #using-github-environments
+
+## Using GitHub Environments
+
+Due to limitations with GitHub, you need to provide `secrets: inherit`. When
+using [Secrets], you must switch the secret names from `[a-z-]+` syntax to
+`[A-Z_]+`. For example: `slack-webhook-url` -> `SLACK_WEBHOOK_URL`.
+
+Example valid workflow:
+
+```yaml
+on:
+  push: [main]
+
+jobs:
+  notify:
+    uses: saleor/saleor-internal-actions/.github/workflows/notify-slack.yaml@main
+    with:
+      github-environment: my-github-environment # <-- replace this with the env's name you created
+    secrets: inherit # <-- Important (only if you want to pass secrets)
+```
 
 ## Examples
 
@@ -138,7 +171,7 @@ on:
       product:
         required: true
         type: string
-      environment:
+      cloud-environment-name:
         required: true
         type: string
 
@@ -156,7 +189,7 @@ jobs:
       type: deployment
       ref: ${{ github.ref_name }}
       product: ${{ inputs.product }}
-      environment: ${{ inputs.environment }}
+      cloud-environment-name: ${{ inputs.cloud-environment-name }}
       status: ${{ needs.deploy.result }}
     secrets:
       slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/notify-slack.yaml
+++ b/.github/workflows/notify-slack.yaml
@@ -4,6 +4,10 @@ name: Notify Slack
 on:
   workflow_call:
     inputs:
+      github-environment:
+        type: string
+        required: false
+        description: The GitHub environment to use to access secrets.
       custom_title:
         type: string
         default: ""
@@ -46,6 +50,14 @@ on:
           The product being deployed (e.g., 'keycloak', 'saleor-multitenant',
           'cloud-api', 'dashboard'). Required when type is 'deployment'.
       environment:
+        type: string
+        default: ""
+        # Note: cannot deprecate directly in inputs (https://github.com/orgs/community/discussions/12564)
+        description: >-
+          [DEPRECATED use cloud-environment-name instead]
+          The target environment (e.g., 'prod', 'staging', 'v322-staging').
+          Required when type is 'deployment'.
+      cloud-environment-name:
         type: string
         default: ""
         description: >-
@@ -97,6 +109,7 @@ jobs:
   notify:
     name: Send Slack notification
     runs-on: ubuntu-24.04
+    environment: ${{ inputs.github-environment }}
 
     outputs:
       ok: ${{ steps.notify-slack.outputs.ok }}
@@ -112,8 +125,10 @@ jobs:
           REF: ${{ inputs.ref }}
           STATUS: ${{ inputs.status }}
           PRODUCT: ${{ inputs.product }}
-          ENVIRONMENT: ${{ inputs.environment }}
-          MENTION_GROUP_ID: ${{ secrets.mention_group_id || inputs.mention_group_id }}
+          ENVIRONMENT: ${{ inputs.environment || inputs.cloud-environment-name }}
+          # Input takes precedence over the secrets as the secret may be set
+          # but the user may not want to use it when using `secrets: inherit`.
+          MENTION_GROUP_ID: ${{ inputs.mention_group_id || secrets.mention_group_id || secrets.MENTION_GROUP_ID }}
           MENTION_ON: ${{ inputs.mention_on }}
           REPO_NAME: ${{ github.event.repository.name }}
           ACTOR: ${{ github.actor }}
@@ -221,7 +236,7 @@ jobs:
         id: notify-slack
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
-          webhook: ${{ secrets.slack-webhook-url }}
+          webhook: ${{ secrets.slack-webhook-url || secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: ${{ steps.generate-payload.outputs.payload }}
           errors: true # We want the workflow to be marked as failed if the notification step fails - otherwise we will be likely to overlook notifications aren't working.


### PR DESCRIPTION
This adds support for the `environment` attribute in our build-push & notify-slack reusable workflows. There are multiple limitations being handled by this PR:
1. `environment` key can only be passed inside the reusable workflow - the caller cannot set it. Hence why we are adding an input `publish-environment`
2. `secrets.XXX` on the caller's end is not supported, instead they need to pass `secrets: inherit` - thus we are documenting this behavior to try to avoid having people falling into this trap as it will cause them to have empty values in the secrets (which will lead to major confusions)
3. GitHub Environments don't support `[a-z-]+` secrets, only `[A-Z_]+` thus we have to support both in our workflow. Note: we could refactor however it would be time consuming (as many place will need updating) and thus not really worthwhile