### PR TITLE
release: v1.12.0

### DIFF
--- a/.github/workflows/run-generate-sbom-and-check-licenses.yaml
+++ b/.github/workflows/run-generate-sbom-and-check-licenses.yaml
@@ -85,7 +85,7 @@ jobs:
       # reusable workflows.
       - if: ${{ !inputs.is_same_repository }}
         name: Generate SBOM
-        uses: saleor/saleor-internal-actions/sbom-generator@v1.11.0
+        uses: saleor/saleor-internal-actions/sbom-generator@166077722d8ab62468ac7def8a2b59594834ee04 # v1.12.0
         with:
           sbom_path: "./bom.json"
           ecosystems: ${{ inputs.ecosystems }}
@@ -140,7 +140,7 @@ jobs:
       - id: license-analyzer-workflow-call
         if: ${{ !inputs.is_same_repository }}
         name: Analyze Licenses
-        uses: saleor/saleor-internal-actions/grant-license-checker@v1.11.0
+        uses: saleor/saleor-internal-actions/grant-license-checker@166077722d8ab62468ac7def8a2b59594834ee04 # v1.12.0
         with:
           rules: ${{ inputs.rules }}
           sbom_path: ./bom.json

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,7 +5,16 @@
 
 To create a new release:
 
-1. Change the version numbers in `.github/workflows/run-generate-sbom-and-check-licenses.yaml` (e.g., `@v1.0.0` -> `@v1.0.1`)
+1. Change the version numbers for **every** action starting with the name
+   `saleor/saleor-internal-actions/` in `.github/workflows/run-generate-sbom-and-check-licenses.yaml`
+
+   For example:
+
+   ```diff
+   - @49a069ae9731cfccf3a1033fe1da4e3da84f4f2a # v1.11.0
+   + @166077722d8ab62468ac7def8a2b59594834ee04 # v1.12.0
+   ```
+
 2. Commit the changes
 3. Create a tag:
    ```
@@ -20,16 +29,7 @@ To create a new release:
    $ git tag --force -s v1.0.1
    $ git push origin --force refs/tags/v1.0.1
    ```
-7. Update the `v1` tag:
-
-   ```
-   git tag -d v1 && git fetch origin tag v1 # resync local copy of v1
-   git fetch --tags
-   git checkout v1.0.1 # Use the version that you want to release
-   git tag --force v1
-   git push origin --force refs/tags/v1
-   ```
-8. Create a release at https://github.com/saleor/saleor-internal-actions/releases/
+6. Create a release at https://github.com/saleor/saleor-internal-actions/releases/
 
    ⚠️ Once you hit the publish button, you will no longer be able to mutate the tag.
    Thus make sure you performed step 5) correctly.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,22 +16,9 @@ To create a new release:
    ```
 
 2. Commit the changes
-3. Create a tag:
-   ```
-   $ git tag -s -m v1.0.1 v1.0.1
-   $ git push --tags
-   ```
-4. Open a pull request with the 1) changes
-5. Once merged, update the v1.0.1 tag's commit SHA:
-   ```
-   $ git checkout main
-   $ git pull
-   $ git tag --force -s v1.0.1
-   $ git push origin --force refs/tags/v1.0.1
-   ```
-6. Create a release at https://github.com/saleor/saleor-internal-actions/releases/
+3. Open a pull request with the 1) changes
+4. Create a release at https://github.com/saleor/saleor-internal-actions/releases/
 
    ⚠️ Once you hit the publish button, you will no longer be able to mutate the tag.
-   Thus make sure you performed step 5) correctly.
 
 [Semantic Versioning]: https://semver.org/

--- a/grant-license-checker/README.md
+++ b/grant-license-checker/README.md
@@ -103,7 +103,7 @@ jobs:
 
       - name: Analyze Licenses
         id: analyze-licenses
-        uses: saleor/saleor-internal-actions/grant-license-checker@v1
+        uses: saleor/saleor-internal-actions/grant-license-checker@v1.x.x
         with:
           # Needs to be a SBOM that contains license information (SPDX, CycloneDX,
           # and Syft formats are supported).
@@ -163,7 +163,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: saleor/saleor-internal-actions/.github/workflows/run-license-check.yaml@v1
+    uses: saleor/saleor-internal-actions/.github/workflows/run-license-check.yaml@v1.x.x
 ```
 
 #### Note: Behavior for External Contributions
@@ -176,7 +176,6 @@ When a pull request originates from a fork, the workflow will always fail with t
 2. Review the summary (where the link sent you at), e.g.:
 
    <div align=center><img alt="Screenshot showing a summary of licenses found in a PR" src="./_docs/assets/external_contribution_workflow_summary.jpg" width="700"/></div>
-
 
 3. If the changes look good to you, then add the label "Licenses Reviewed" to the pull request (case-sensitive, create the label if it doesn't exist)
 4. Once labeled, the workflow will rerun and will succeed.

--- a/request-vault-token/README.md
+++ b/request-vault-token/README.md
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Get Token
         id: get-token
-        uses: saleor/saleor-internal-actions/request-vault-token@v1
+        uses: saleor/saleor-internal-actions/request-vault-token@v1.x.x
         with:
           # Provides required inputs
           vault-url: ${{ secrets.VAULT_URL }}

--- a/sbom-generator/README.md
+++ b/sbom-generator/README.md
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Analyze Licenses
-        uses: saleor/saleor-internal-actions/sbom-generator@v1
+        uses: saleor/saleor-internal-actions/sbom-generator@v1.x.x
         with:
           # Where to store the resulting SBOM file (default is ./sbom.json).
           sbom_path: ./sbom.json

--- a/sbom-generator/action.yaml
+++ b/sbom-generator/action.yaml
@@ -27,7 +27,7 @@ runs:
   using: composite
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: 20
 


### PR DESCRIPTION
- Bumps version to v1.12.0
- Makes the release immutable by pinning to the full SHA-length (which otherwise prevents GitHub repositories from using our actions when they enable 'Require actions to be pinned to a full-length commit SHA' - https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/)
- Removes insecure v1 tags in favor of v1.x.x syntax to not encourage users from using mutable tags (+ allows to simplify the release process) (inspired by https://github.com/astral-sh/setup-uv/releases/tag/v8.0.0)

## Changes since v1.11.0

Chores:

- Bumped `docker/build-push-action` from 6.19.2 to 7.0.0 (#65)
- Bumped `slackapi/slack-github-action` from 2.1.1 to 3.0.1 (#67)
- Bumped `actions/download-artifact` from 8.0.0 to 8.0.1 (#69)
- Bumped `docker/setup-buildx-action` from 3.12.0 to 4.0.0 (#68)
- Bumped `aws-actions/amazon-ecr-login` from 2.0.1 to 2.1.1 (#66)
- (Security) License-checker: switched from Poetry to uv (#74)

Enhancements:
- (Security) Build-push re-usable workflow: pinned the Buildx and Buildkit versions used by buildx + disabled download cache by default (#72)
- (Security) Build-push: disabled cache by default (#70)